### PR TITLE
fix: enforce CGO_ENABLED=0 in Makefile build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT)
 .PHONY: build install clean test unit-test lint fmt fmt-docs check setup release-dry release-check
 
 build:
-	go build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/howl
+	CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/howl
 
 install: build
 	mkdir -p $(INSTALL_DIR)


### PR DESCRIPTION
## Summary
- Align local `make build` with release builds by explicitly setting `CGO_ENABLED=0`
- Matches the project's critical constraint: zero external dependencies, static cross-compilation

## Test plan
- [x] `make build` succeeds with `CGO_ENABLED=0`
- [x] Smoke test passes (`echo '{}' | ./build/howl`)
- [ ] Auto-release pipeline correctly syncs plugin.json version after merge

> **Note:** This PR also validates the new plugin.json version auto-sync in `auto-release.yaml`.