### PR TITLE
fix: OAuth token extraction and schema alignment

### DIFF
--- a/internal/types.go
+++ b/internal/types.go
@@ -5,16 +5,18 @@ import "strings"
 // StdinData represents the top-level JSON structure piped by Claude Code every ~300ms.
 // It contains session metrics, context window usage, cost data, and workspace information.
 type StdinData struct {
-	SessionID      string        `json:"session_id"`
-	TranscriptPath string        `json:"transcript_path"`
-	CWD            string        `json:"cwd"`
-	Version        string        `json:"version"`
-	Model          Model         `json:"model"`
-	Workspace      Workspace     `json:"workspace"`
-	Cost           Cost          `json:"cost"`
-	ContextWindow  ContextWindow `json:"context_window"`
-	Vim            *Vim          `json:"vim"`
-	Agent          *Agent        `json:"agent"`
+	SessionID         string        `json:"session_id"`
+	TranscriptPath    string        `json:"transcript_path"`
+	CWD               string        `json:"cwd"`
+	Version           string        `json:"version"`
+	Model             Model         `json:"model"`
+	Workspace         Workspace     `json:"workspace"`
+	Cost              Cost          `json:"cost"`
+	ContextWindow     ContextWindow `json:"context_window"`
+	Exceeds200KTokens bool          `json:"exceeds_200k_tokens"`
+	OutputStyle       *OutputStyle  `json:"output_style"`
+	Vim               *Vim          `json:"vim"`
+	Agent             *Agent        `json:"agent"`
 }
 
 // Model represents the AI model being used for the session.
@@ -54,6 +56,11 @@ type CurrentUsage struct {
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}
+
+// OutputStyle represents the current output style configuration.
+type OutputStyle struct {
+	Name string `json:"name"`
 }
 
 // Vim represents the current vim mode if enabled in Claude Code.


### PR DESCRIPTION
## Summary
- **Fix truncated Keychain JSON parsing**: macOS `security -w` truncates output at ~2KB when multiple credentials are stored (OAuth + MCP servers), producing invalid JSON. Replace `json.Unmarshal` with regex extraction for the `accessToken` field, which is robust against truncation.
- **Add new statusline schema fields**: Align `StdinData` with the latest Claude Code statusline JSON schema — adds `exceeds_200k_tokens` (bool) and `output_style` (object) for forward compatibility.

## Root Cause
The Keychain stores all Claude Code credentials in a single JSON blob. When additional providers (e.g., Linear MCP) are registered, the blob exceeds the ~2KB output limit of `security -w`, producing truncated JSON (9 open braces, 4 close braces). This caused `getOAuthToken()` to silently fail, making `GetUsage()` return nil, which collapsed the statusline layout from 4 lines (with quota progress bars) to 2 lines.

## Test plan
- [x] `extractAccessToken` unit tests: valid JSON, truncated JSON, control characters, empty input, missing field
- [x] Full test suite passes (95.5% coverage)
- [x] `make check` passes (fmt + lint + unit-test)
- [x] E2E verified: new binary produces 3-line layout with quota bars (vs 2-line before fix)