### PR TITLE
feat: modernize statusline for Claude Code 2.1 (rate_limits, schema, new metrics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,8 +383,8 @@ howl/
 
 ### Key Modules
 
-- **constants.go** — Default threshold constants (danger %, cache %, speed, cost, quotas, timeouts)
-- **config.go** — Configuration system with presets, feature toggles, and 17 customizable thresholds
+- **constants.go** — Default threshold constants (danger %, cache %, cost, quotas, timeouts)
+- **config.go** — Configuration system with presets, feature toggles, and 15 customizable thresholds
 - **types.go** — StdinData schema matching Claude Code's JSON output, model tier classification
 - **metrics.go** — Cache efficiency, API ratio, cost velocity calculations
 - **render.go** — ANSI color codes, adaptive layouts (normal 2-4 lines / danger 2 lines), threshold-driven colors

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A blazing-fast, feature-rich statusline HUD for [Claude Code](https://code.claud
 [![Commit Activity](https://img.shields.io/github/commit-activity/m/ai-screams/howl?logo=github&logoColor=white)](https://github.com/ai-screams/howl/graphs/commit-activity)
 
 [![CI](https://img.shields.io/github/actions/workflow/status/ai-screams/howl/ci.yaml?label=CI&logo=githubactions&logoColor=white)](https://github.com/ai-screams/howl/actions)
-[![Coverage](https://img.shields.io/badge/Coverage-95.2%25-brightgreen?logo=go&logoColor=white)]()
-[![Tests](https://img.shields.io/badge/Tests-129%20passed-brightgreen?logo=testinglibrary&logoColor=white)]()
+[![Coverage](https://img.shields.io/badge/Coverage-95.4%25-brightgreen?logo=go&logoColor=white)]()
+[![Tests](https://img.shields.io/badge/Tests-119%20passed-brightgreen?logo=testinglibrary&logoColor=white)]()
 [![Go Report](https://goreportcard.com/badge/github.com/ai-screams/howl)](https://goreportcard.com/report/github.com/ai-screams/howl)
 [![Go Reference](https://pkg.go.dev/badge/github.com/ai-screams/howl.svg)](https://pkg.go.dev/github.com/ai-screams/howl)
 [![Security](https://img.shields.io/badge/govulncheck-passing-brightgreen?logo=go&logoColor=white)]()
@@ -34,7 +34,7 @@ A blazing-fast, feature-rich statusline HUD for [Claude Code](https://code.claud
 
 ![Howl in action](assets/normal.png)
 
-_Real-time statusline HUD showing 1M context session with 13 intelligent metrics_
+_Real-time statusline HUD showing 1M context session with 17 intelligent metrics_
 
 ---
 
@@ -208,13 +208,14 @@ Restart Claude Code to activate the statusline. The HUD will appear at the botto
 
 ## Updating 🔄
 
-### If installed via Plugin
+### If installed via Plugin (automatic)
 
-```bash
-/howl:setup
-```
+The binary keeps itself in sync with the plugin — no manual step needed:
 
-Re-running the setup skill downloads the latest binary and replaces the existing one. Your configuration (`~/.claude/hud/config.json`) is preserved.
+1. Claude Code auto-updates the **plugin** content from the marketplace (enable marketplace auto-update; third-party marketplaces are not auto-updated by default: `claude plugin marketplace update ai-screams-howl`).
+2. The plugin's `SessionStart` hook (`scripts/sync-binary.sh`) detects the new plugin version and re-downloads the matching **binary** in the background.
+
+It is a no-op (no network) when already in sync, only updates an existing install, and never blocks session start. To force an immediate update, re-run `/howl:setup`. Your configuration (`~/.claude/hud/config.json`) is always preserved.
 
 ### If installed via Direct Download
 
@@ -276,9 +277,9 @@ Howl runs automatically as a subprocess every ~300ms. No manual interaction need
 <summary>Text output (for accessibility)</summary>
 
 ```
-🟢 Sonnet 4.5 1M | hanyul.ryu@gmail.com | main | $24.5 | 29h15m
+🟢 Sonnet 4.5 1M | hanyul.ryu@gmail.com | main | Out:1K | $24.5 | 29h15m
 ██░░░░░░░░  21% (210K/  1M) | ████████░░  78% (2h00m/5h) | █████████░  88% (3d21h/7d)
-+328 -67 | Cache 99% (R:180K W:30K) | Wait 6% | $0.01/m | Out:1K | VIM:I | CC 1.0.18
++328 -67 | Cache 99% (R:180K W:30K) | Wait 6% | $0.01/m | VIM:I | CC 1.0.18
 Bash(2)
 ```
 
@@ -376,7 +377,12 @@ howl/
 │   ├── configure/SKILL.md   # /howl:configure (preset selection)
 │   ├── customize/SKILL.md   # /howl:customize (metric toggles)
 │   └── threshold/SKILL.md   # /howl:threshold (color thresholds)
-├── .claude-plugin/          # Claude Code plugin metadata
+├── hooks/
+│   └── hooks.json           # SessionStart hook: binary auto-update
+├── scripts/
+│   ├── install.sh           # Download binary + configure statusLine
+│   └── sync-binary.sh       # Keep binary in sync with plugin version
+├── .claude-plugin/          # Claude Code plugin metadata (plugin.json, marketplace.json)
 ├── Makefile                 # Build automation
 └── go.mod                   # Go module definition
 ```
@@ -552,14 +558,14 @@ Howl was created to solve specific pain points with existing Claude Code statusl
 | Cold start         | ~70ms (Node.js) | ~10ms (Go)                   |
 | Dependencies       | npm ecosystem   | Zero (stdlib only)           |
 | Context display    | % only          | Absolute (500K/1M)           |
-| Metrics count      | 3-5             | 13                           |
+| Metrics count      | 3-5             | 17                           |
 | 1M context support | ❌              | ✅                           |
 | Quota source       | ❌ Missing      | ✅ stdin `rate_limits` field |
 
 ### What Makes Howl Different
 
 - **Zero-latency quota** — Reads `rate_limits` directly from stdin (no network call, no Keychain)
-- **Rich metrics** — 13 distinct indicators across 2-4 display lines
+- **Rich metrics** — 17 distinct indicators across 2-4 display lines
 - **Go performance** — ~10ms cold start, 5.6MB binary, zero dependencies
 - **1M context ready** — Adaptive K/M formatting for large windows
 - **Width-aware rendering** — Tool/agent line adapts to terminal width via `COLUMNS`
@@ -572,7 +578,7 @@ Howl was created to solve specific pain points with existing Claude Code statusl
 
 - [x] Configuration file support (`~/.claude/hud/config.json`) — _Available in v1.3.0+_
 - [x] Auto-sync plugin.json version in release pipeline — _Available in v1.4.0+_
-- [x] Custom thresholds — 17 configurable color breakpoints and danger mode trigger — _Available in v1.5.0+_
+- [x] Custom thresholds — 15 configurable color breakpoints and danger mode trigger — _Available in v1.5.0+_
 - [ ] Custom color schemes
 - [ ] Plugin system for custom metrics
 - [ ] Windows support

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ _Real-time statusline HUD showing 1M context session with 13 intelligent metrics
 
 - **Cache Efficiency** — Track prompt cache utilization (80%+ = excellent)
 - **API Wait Ratio** — See how much time spent waiting for AI responses
-- **Response Speed** — Real-time tokens/second output rate
 - **Cost Velocity** — Monitor spending rate ($/minute)
 
 ### Essential Status 🎯
@@ -73,7 +72,7 @@ _Real-time statusline HUD showing 1M context session with 13 intelligent metrics
 - **Model Tier Badge** — Color-coded Opus (gold) / Sonnet (cyan) / Haiku (green)
 - **Context Health Bar** — Visual 10-char bar with 4-tier gradient
 - **Token Absolutes** — See exact usage (210K/1M) with adaptive K/M formatting
-- **Usage Quota** — Live 5h/7d limits with reset countdowns
+- **Usage Quota** — Live 5h/7d limits with reset countdowns (reads `rate_limits` from stdin; requires Claude.ai subscriber + CC 2.1.80+)
 
 ### Workflow Awareness 🔧
 
@@ -85,16 +84,28 @@ _Real-time statusline HUD showing 1M context session with 13 intelligent metrics
 
 ### Custom Thresholds ⚡
 
-- **17 Configurable Values** — Control when every color changes and when danger mode activates
-- **Per-Group Tuning** — Context, cost, cache, speed, API wait, cost velocity, quota
+- **15 Configurable Values** — Control when every color changes and when danger mode activates
+- **Per-Group Tuning** — Context, cost, cache, API wait, cost velocity, quota
 - **Interactive Setup** — Use `/howl:threshold` to adjust values conversationally
 - **Safe Defaults** — Invalid values auto-corrected, zero values ignored
+
+### Optional Feature Toggles (default off) 🔧
+
+Enable individually via `features` in `~/.claude/hud/config.json` or `/howl:customize`:
+
+- **output_tokens** — Current-response output token count (`Out:1K`) — truthful replacement for the removed tok/s metric; reads `current_usage.output_tokens` directly
+- **effort** — Shows current effort level (`E:high`)
+- **thinking** — Shows extended thinking indicator (`Think`)
+- **session_name** — Shows truncated session name
+- **pull_request** — Shows linked PR (`PR#1234 pending`)
+- **worktree** — Shows active git worktree (`wt:name`)
 
 ### Adaptive Layouts 🎨
 
 - **Normal Mode** (< 85% context, configurable) — 2-4 line display (lines added as features activate)
 - **Danger Mode** (85%+ context, configurable) — Dense 2-line view with token breakdown and hourly cost
 - **Smart Grouping** — Logical organization of related metrics
+- **Width-Aware Rendering** — Tool/agent line sizes to `COLUMNS` env var (clamped 40–240, fallback 80; requires CC 2.1.153+)
 
 ---
 
@@ -265,9 +276,9 @@ Howl runs automatically as a subprocess every ~300ms. No manual interaction need
 <summary>Text output (for accessibility)</summary>
 
 ```
-🟢 Sonnet 4.5 1M | hanyul.ryu@gmail.com | main | 15 tok/s | $24.5 | 29h15m
+🟢 Sonnet 4.5 1M | hanyul.ryu@gmail.com | main | $24.5 | 29h15m
 ██░░░░░░░░  21% (210K/  1M) | ████████░░  78% (2h00m/5h) | █████████░  88% (3d21h/7d)
-+328 -67 | Cache 99% (R:180K W:30K) | Wait 6% | $0.01/m | VIM:I | CC 1.0.18
++328 -67 | Cache 99% (R:180K W:30K) | Wait 6% | $0.01/m | Out:1K | VIM:I | CC 1.0.18
 Bash(2)
 ```
 
@@ -282,21 +293,22 @@ Bash(2)
 
 ```
 🟣 Opus 4.6 | 🔴 ██████████ 100% 0K left ~0m | ████████░░  72% (2h00m/5h)
-main | +328 -67 | 15 tok/s | Cache 99% | Wait 6% | $0.01/m
+main | +328 -67 | Cache 99% | Wait 6% | $0.01/m
 ```
 
 </details>
 
 ### Metrics Explained
 
-| Metric             | Meaning                                         | Color Coding                                      |
-| ------------------ | ----------------------------------------------- | ------------------------------------------------- |
-| **Cache 96%**      | Prompt cache efficiency (% of input from cache) | Green (80%+), Yellow (50-80%), Red (<50%)         |
-| **Wait 41%**       | Time spent waiting for API responses            | Green (<35%), Yellow (35-60%), Red (60%+)         |
-| **$0.19/m**        | API spending rate per minute                    | Green (<$0.10), Yellow ($0.10-0.50), Red ($0.50+) |
-| **50 tok/s**       | Output token generation speed                   | Green (60+), Yellow (30-60), Orange (<30)         |
-| **78% (2h00m/5h)** | 5-hour quota: 78% remaining, resets in 2h       | Gradient based on % remaining                     |
-| **88% (3d21h/7d)** | 7-day quota: 88% remaining, resets in 3d21h     | Gradient based on % remaining                     |
+| Metric              | Meaning                                                                         | Color Coding                                                                         |
+| ------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Cache 96%**       | Prompt cache efficiency (% of input from cache)                                 | Green (80%+), Yellow (50-80%), Red (<50%)                                            |
+| **Wait 41%**        | Time spent waiting for API responses                                            | Green (<35%), Yellow (35-60%), Red (60%+)                                            |
+| **$0.19/m**         | API spending rate per minute                                                    | Green (<$0.10), Yellow ($0.10-0.50), Red ($0.50+)                                    |
+| **Out:1K**          | Output tokens for the current response                                          | Static (no color coding; opt-in via `output_tokens` toggle)                          |
+| **78% (2h00m/5h)**  | 5-hour quota: 78% remaining, resets in 2h                                       | Gradient based on % remaining                                                        |
+| **88% (3d21h/7d)**  | 7-day quota: 88% remaining, resets in 3d21h                                     | Gradient based on % remaining                                                        |
+| **🔥 on quota bar** | Quota window is ahead of even pace — projected to be exhausted before it resets | Appended to the quota bar; no separate toggle (shows under existing `quota` feature) |
 
 > **Tip:** All color thresholds above are defaults. You can customize every breakpoint via `/howl:threshold` or `~/.claude/hud/config.json`. See [Custom Thresholds](#custom-thresholds) below.
 
@@ -311,7 +323,7 @@ main | +328 -67 | 15 tok/s | Cache 99% | Wait 6% | $0.01/m
 ```
 Claude Code (every ~300ms)
     │
-    ├─ Pipes JSON to stdin
+    ├─ Pipes JSON to stdin (includes rate_limits for quota)
     │
     ▼
 ┌─────────────────────────────────────┐
@@ -320,7 +332,7 @@ Claude Code (every ~300ms)
 │  1. Parse stdin JSON                │
 │  2. Compute derived metrics         │
 │  3. Fetch git status (1s timeout)   │
-│  4. Get OAuth quota (60s cache)     │
+│  4. Convert rate_limits → quota     │
 │  5. Parse transcript (last 100 ln)  │
 │  6. Render ANSI output              │
 │  7. Output to stdout                │
@@ -350,7 +362,7 @@ howl/
 │   ├── config_test.go       # Config tests
 │   ├── git.go               # Git subprocess calls
 │   ├── git_test.go          # Git tests
-│   ├── usage.go             # OAuth quota API
+│   ├── usage.go             # rate_limits → quota converter (no I/O)
 │   ├── usage_test.go        # Usage tests
 │   ├── account.go           # Account tier detection
 │   ├── account_test.go      # Account tests
@@ -374,10 +386,10 @@ howl/
 - **constants.go** — Default threshold constants (danger %, cache %, speed, cost, quotas, timeouts)
 - **config.go** — Configuration system with presets, feature toggles, and 17 customizable thresholds
 - **types.go** — StdinData schema matching Claude Code's JSON output, model tier classification
-- **metrics.go** — Cache efficiency, API ratio, cost velocity, response speed calculations
+- **metrics.go** — Cache efficiency, API ratio, cost velocity calculations
 - **render.go** — ANSI color codes, adaptive layouts (normal 2-4 lines / danger 2 lines), threshold-driven colors
 - **git.go** — Branch detection with graceful 1s timeout
-- **usage.go** — Anthropic OAuth API client with session-scoped 60s caching
+- **usage.go** — Pure `rate_limits` → quota converter (no network/Keychain/cache)
 - **transcript.go** — Tool usage extraction from conversation history (last ~100 lines)
 
 ---
@@ -392,26 +404,24 @@ howl/
 - Go: 1.24.13
 - Runs: 20 iterations (minimal), 10 iterations (full)
 
-| Mode                     | Min  | Max     | Average  | Budget      |
-| ------------------------ | ---- | ------- | -------- | ----------- |
-| **Minimal** (stdin-only) | 0ms  | 20ms    | **6ms**  | 300ms (2%)  |
-| **Full** (all features)  | 30ms | 510ms\* | **88ms** | 300ms (29%) |
-
-\*First OAuth call (uncached)
+| Mode                     | Min  | Max  | Average  | Budget      |
+| ------------------------ | ---- | ---- | -------- | ----------- |
+| **Minimal** (stdin-only) | 0ms  | 20ms | **6ms**  | 300ms (2%)  |
+| **Full** (all features)  | 30ms | 80ms | **45ms** | 300ms (15%) |
 
 ### Breakdown by Feature
 
-| Feature               | Added Latency               | Notes                     |
-| --------------------- | --------------------------- | ------------------------- |
-| JSON parsing + render | ~6ms                        | Base operation            |
-| Git status            | +20-40ms                    | 1s timeout, graceful fail |
-| Transcript parsing    | +10-30ms                    | Last 100 lines only       |
-| OAuth quota           | +3s (first) / +0ms (cached) | 60s cache TTL             |
+| Feature               | Added Latency | Notes                                       |
+| --------------------- | ------------- | ------------------------------------------- |
+| JSON parsing + render | ~6ms          | Base operation                              |
+| Git status            | +20-40ms      | 1s timeout, graceful fail                   |
+| Transcript parsing    | +10-30ms      | Last 100 lines only                         |
+| Quota (rate_limits)   | +0ms          | Parsed directly from stdin, no network call |
 
 **Optimizations:**
 
 - Compiled Go binary (no interpreter startup)
-- Session-scoped caching for external API calls
+- Quota read directly from stdin (no network call, no caching needed)
 - Tail-only transcript parsing (vs full file scan)
 - 1-second timeout on git operations
 - Zero external dependencies (stdlib only)
@@ -467,7 +477,7 @@ func renderNewMetric(val int) string {
 
 ### Custom Thresholds
 
-All 17 color breakpoints and the danger mode trigger are configurable via `~/.claude/hud/config.json`:
+All 15 color breakpoints and the danger mode trigger are configurable via `~/.claude/hud/config.json`:
 
 ```json
 {
@@ -476,7 +486,6 @@ All 17 color breakpoints and the danger mode trigger are configurable via `~/.cl
     "context_danger": 92,
     "context_warning": 80,
     "session_cost_high": 20.0,
-    "speed_fast": 100,
     "quota_high": 90
   }
 }
@@ -490,7 +499,6 @@ Only specified values override defaults — omitted fields keep their default va
 | **Session Cost**  | `session_cost_high`, `session_cost_medium`                  | $5.00, $1.00                 | Cost display color                           |
 | **Cache**         | `cache_excellent`, `cache_good`                             | 80%, 50%                     | Cache efficiency color                       |
 | **API Wait**      | `wait_high`, `wait_medium`                                  | 60%, 35%                     | API wait ratio color                         |
-| **Speed**         | `speed_fast`, `speed_moderate`                              | 60, 30 tok/s                 | Response speed color                         |
 | **Cost Velocity** | `cost_velocity_high`, `cost_velocity_medium`                | $0.50, $0.10/min             | Cost velocity color                          |
 | **Quota**         | `quota_critical`, `quota_low`, `quota_medium`, `quota_high` | 10%, 25%, 50%, 75% remaining | Quota color bands                            |
 
@@ -500,31 +508,19 @@ Only specified values override defaults — omitted fields keep their default va
 
 Changes apply on the next refresh (~300ms) — no restart needed.
 
-### OAuth Credentials
-
-Howl automatically reads OAuth tokens from macOS Keychain:
-
-- Service: `Claude Code-credentials`
-- Extracted field: `claudeAiOauth.accessToken`
-
-No manual configuration needed if Claude Code is authenticated.
-
-### Cache Locations
-
-- **Usage quota cache:** `$TMPDIR/howl-{session_id}/usage.json` (60s TTL)
-- **Session-scoped:** Each Claude Code session has isolated cache via `session_id`
-
 ---
 
 <a name="troubleshooting"></a>
 
 ## Troubleshooting 🔍
 
-### Quota shows `?`
+### Quota shows `?` or is absent
 
-- OAuth API unavailable or credentials expired
-- Check: `security find-generic-password -s "Claude Code-credentials" -w`
-- Fallback: Quota display is optional, other metrics still work
+- Not a Claude.ai subscriber (quota only available for subscribers)
+- Before the first API response in the session (quota field appears after the first call)
+- Claude Code older than 2.1.80 (the `rate_limits` stdin field was added in 2.1.80)
+- Each quota window (`five_hour`/`seven_day`) can be independently absent — no bar renders for that window rather than showing a fake 0%
+- Fallback: Quota display is optional, all other metrics still work
 
 ### Git branch not showing
 
@@ -541,8 +537,7 @@ No manual configuration needed if Claude Code is authenticated.
 ### Performance slower than expected
 
 - Large transcript file (>10MB)
-- Network latency for OAuth API
-- Solution: Transcript parses last 100 lines only, quota cached for 60s
+- Solution: Transcript parses last 100 lines only; quota has zero latency (read from stdin)
 
 ---
 
@@ -552,23 +547,22 @@ Howl was created to solve specific pain points with existing Claude Code statusl
 
 ### Comparison
 
-| Feature            | claude-hud        | Howl               |
-| ------------------ | ----------------- | ------------------ |
-| Cold start         | ~70ms (Node.js)   | ~10ms (Go)         |
-| Dependencies       | npm ecosystem     | Zero (stdlib only) |
-| Context display    | % only            | Absolute (500K/1M) |
-| Metrics count      | 3-5               | 13                 |
-| 1M context support | ❌                | ✅                 |
-| Session isolation  | ❌ Global cache   | ✅ Per session_id  |
-| OAuth quota        | ❌ Missing header | ✅ Correct API     |
+| Feature            | claude-hud      | Howl                         |
+| ------------------ | --------------- | ---------------------------- |
+| Cold start         | ~70ms (Node.js) | ~10ms (Go)                   |
+| Dependencies       | npm ecosystem   | Zero (stdlib only)           |
+| Context display    | % only          | Absolute (500K/1M)           |
+| Metrics count      | 3-5             | 13                           |
+| 1M context support | ❌              | ✅                           |
+| Quota source       | ❌ Missing      | ✅ stdin `rate_limits` field |
 
 ### What Makes Howl Different
 
-- **Session isolation** — Cache per `session_id`, preventing cross-session bugs
-- **OAuth headers** — Correct `anthropic-beta` header included for API access
+- **Zero-latency quota** — Reads `rate_limits` directly from stdin (no network call, no Keychain)
 - **Rich metrics** — 13 distinct indicators across 2-4 display lines
 - **Go performance** — ~10ms cold start, 5.6MB binary, zero dependencies
 - **1M context ready** — Adaptive K/M formatting for large windows
+- **Width-aware rendering** — Tool/agent line adapts to terminal width via `COLUMNS`
 
 ---
 

--- a/cmd/howl/main.go
+++ b/cmd/howl/main.go
@@ -43,8 +43,8 @@ func main() {
 	}
 	git := internal.GetGitInfo(dir)
 
-	// Try to fetch usage quota (optional)
-	usage := internal.GetUsage(data.SessionID)
+	// Quota comes directly from stdin rate_limits (optional, subscriber-only)
+	usage := internal.UsageFromRateLimits(data.RateLimits)
 
 	// Parse transcript for tools/agents (optional)
 	toolInfo := internal.ParseTranscript(data.TranscriptPath)

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Keep the Howl binary in sync with the installed plugin version on session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/sync-binary.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/internal/config.go
+++ b/internal/config.go
@@ -28,8 +28,6 @@ type Thresholds struct {
 	CacheGood          int     `json:"cache_good"`           // Cache % for yellow (default 50)
 	WaitHigh           int     `json:"wait_high"`            // API wait % for red (default 60)
 	WaitMedium         int     `json:"wait_medium"`          // API wait % for yellow (default 35)
-	SpeedFast          int     `json:"speed_fast"`           // tok/s for green (default 60)
-	SpeedModerate      int     `json:"speed_moderate"`       // tok/s for yellow (default 30)
 	CostVelocityHigh   float64 `json:"cost_velocity_high"`   // $/min for red (default 0.50)
 	CostVelocityMedium float64 `json:"cost_velocity_medium"` // $/min for yellow (default 0.10)
 	QuotaCritical      float64 `json:"quota_critical"`       // Remaining % for bold red (default 10)
@@ -43,7 +41,7 @@ type FeatureToggles struct {
 	Account         bool `json:"account"`
 	Git             bool `json:"git"`
 	LineChanges     bool `json:"line_changes"`
-	ResponseSpeed   bool `json:"response_speed"`
+	OutputTokens    bool `json:"output_tokens"`
 	Quota           bool `json:"quota"`
 	Tools           bool `json:"tools"`
 	Agents          bool `json:"agents"`
@@ -52,6 +50,13 @@ type FeatureToggles struct {
 	CostVelocity    bool `json:"cost_velocity"`
 	VimMode         bool `json:"vim_mode"`
 	AgentName       bool `json:"agent_name"`
+	// Optional CC 2.1 field renderers. Off in every preset by default to keep the
+	// normal layout uncluttered — opt in explicitly via config features override.
+	Effort      bool `json:"effort"`
+	Thinking    bool `json:"thinking"`
+	SessionName bool `json:"session_name"`
+	PullRequest bool `json:"pull_request"`
+	Worktree    bool `json:"worktree"`
 }
 
 var presets = map[string]FeatureToggles{
@@ -59,7 +64,7 @@ var presets = map[string]FeatureToggles{
 		Account:         true,
 		Git:             true,
 		LineChanges:     true,
-		ResponseSpeed:   true,
+		OutputTokens:    true,
 		Quota:           true,
 		Tools:           true,
 		Agents:          true,
@@ -74,7 +79,7 @@ var presets = map[string]FeatureToggles{
 		Account:         true,
 		Git:             true,
 		LineChanges:     true,
-		ResponseSpeed:   true,
+		OutputTokens:    true,
 		Quota:           true,
 		Tools:           true,
 		Agents:          true,
@@ -82,16 +87,16 @@ var presets = map[string]FeatureToggles{
 		VimMode:         true,
 	},
 	"cost-focused": {
-		Account:       true,
-		ResponseSpeed: true,
-		Quota:         true,
-		APIWaitRatio:  true,
-		CostVelocity:  true,
+		Account:      true,
+		OutputTokens: true,
+		Quota:        true,
+		APIWaitRatio: true,
+		CostVelocity: true,
 	},
 }
 
 // mergeFeatures merges override into base. If override field is true, it overrides base.
-// If override field is false, base value is preserved (no reflection, explicit for all 12 fields).
+// If override field is false, base value is preserved (no reflection, explicit per field).
 func mergeFeatures(base, override FeatureToggles) FeatureToggles {
 	result := base
 	if override.Account {
@@ -103,8 +108,8 @@ func mergeFeatures(base, override FeatureToggles) FeatureToggles {
 	if override.LineChanges {
 		result.LineChanges = true
 	}
-	if override.ResponseSpeed {
-		result.ResponseSpeed = true
+	if override.OutputTokens {
+		result.OutputTokens = true
 	}
 	if override.Quota {
 		result.Quota = true
@@ -130,6 +135,21 @@ func mergeFeatures(base, override FeatureToggles) FeatureToggles {
 	if override.AgentName {
 		result.AgentName = true
 	}
+	if override.Effort {
+		result.Effort = true
+	}
+	if override.Thinking {
+		result.Thinking = true
+	}
+	if override.SessionName {
+		result.SessionName = true
+	}
+	if override.PullRequest {
+		result.PullRequest = true
+	}
+	if override.Worktree {
+		result.Worktree = true
+	}
 	return result
 }
 
@@ -145,8 +165,6 @@ func DefaultThresholds() Thresholds {
 		CacheGood:          CacheGood,
 		WaitHigh:           WaitHigh,
 		WaitMedium:         WaitMedium,
-		SpeedFast:          SpeedFast,
-		SpeedModerate:      SpeedModerate,
 		CostVelocityHigh:   CostHigh,
 		CostVelocityMedium: CostMedium,
 		QuotaCritical:      QuotaCritical,
@@ -187,12 +205,6 @@ func mergeThresholds(base, override Thresholds) Thresholds {
 	if override.WaitMedium > 0 {
 		result.WaitMedium = override.WaitMedium
 	}
-	if override.SpeedFast > 0 {
-		result.SpeedFast = override.SpeedFast
-	}
-	if override.SpeedModerate > 0 {
-		result.SpeedModerate = override.SpeedModerate
-	}
 	if override.CostVelocityHigh > 0 {
 		result.CostVelocityHigh = override.CostVelocityHigh
 	}
@@ -227,10 +239,6 @@ func validateThresholds(t *Thresholds) {
 	t.WaitHigh = max(0, min(t.WaitHigh, 100))
 	t.WaitMedium = max(0, min(t.WaitMedium, 100))
 
-	// Speed: fast minimum 2 (to allow moderate >= 1), moderate minimum 1
-	t.SpeedFast = max(2, t.SpeedFast)
-	t.SpeedModerate = max(1, t.SpeedModerate)
-
 	// Cost: minimum 0.01
 	t.SessionCostHigh = max(0.01, t.SessionCostHigh)
 	t.SessionCostMedium = max(0.01, t.SessionCostMedium)
@@ -260,9 +268,6 @@ func validateThresholds(t *Thresholds) {
 	// API wait: high > medium
 	t.WaitMedium = max(0, min(t.WaitMedium, t.WaitHigh-1))
 
-	// Speed: fast > moderate
-	t.SpeedModerate = max(1, min(t.SpeedModerate, t.SpeedFast-1))
-
 	// Cost velocity: high > medium
 	if t.CostVelocityMedium >= t.CostVelocityHigh {
 		t.CostVelocityMedium = max(0.01, t.CostVelocityHigh*0.5)
@@ -278,7 +283,6 @@ func validateThresholds(t *Thresholds) {
 	t.ContextModerate = max(0, min(t.ContextModerate, 100))
 	t.CacheGood = max(0, min(t.CacheGood, 100))
 	t.WaitMedium = max(0, min(t.WaitMedium, 100))
-	t.SpeedModerate = max(1, t.SpeedModerate)
 	t.SessionCostMedium = max(0.01, t.SessionCostMedium)
 	t.CostVelocityMedium = max(0.01, t.CostVelocityMedium)
 	t.QuotaLow = max(0, min(t.QuotaLow, 100))

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -243,7 +243,7 @@ func TestMergeFeatures_Override(t *testing.T) {
 func TestMergeFeatures_AllTrue(t *testing.T) {
 	base := FeatureToggles{Account: false}
 	override := FeatureToggles{
-		Account: true, Git: true, LineChanges: true, ResponseSpeed: true,
+		Account: true, Git: true, LineChanges: true, OutputTokens: true,
 		Quota: true, Tools: true, Agents: true, CacheEfficiency: true,
 		APIWaitRatio: true, CostVelocity: true, VimMode: true, AgentName: true,
 	}
@@ -314,12 +314,6 @@ func TestDefaultThresholds(t *testing.T) {
 	if th.WaitMedium != WaitMedium {
 		t.Errorf("WaitMedium: expected %d, got %d", WaitMedium, th.WaitMedium)
 	}
-	if th.SpeedFast != SpeedFast {
-		t.Errorf("SpeedFast: expected %d, got %d", SpeedFast, th.SpeedFast)
-	}
-	if th.SpeedModerate != SpeedModerate {
-		t.Errorf("SpeedModerate: expected %d, got %d", SpeedModerate, th.SpeedModerate)
-	}
 	if th.CostVelocityHigh != CostHigh {
 		t.Errorf("CostVelocityHigh: expected %.2f, got %.2f", CostHigh, th.CostVelocityHigh)
 	}
@@ -350,9 +344,6 @@ func TestMergeThresholds_AllZero(t *testing.T) {
 	if result.ContextDanger != DangerThreshold {
 		t.Errorf("ContextDanger should be preserved: expected %d, got %d", DangerThreshold, result.ContextDanger)
 	}
-	if result.SpeedFast != SpeedFast {
-		t.Errorf("SpeedFast should be preserved: expected %d, got %d", SpeedFast, result.SpeedFast)
-	}
 	if result.QuotaCritical != QuotaCritical {
 		t.Errorf("QuotaCritical should be preserved: expected %.1f, got %.1f", float64(QuotaCritical), result.QuotaCritical)
 	}
@@ -362,7 +353,6 @@ func TestMergeThresholds_PartialOverride(t *testing.T) {
 	base := DefaultThresholds()
 	override := Thresholds{
 		ContextDanger:      90,
-		SpeedFast:          100,
 		SessionCostHigh:    10.0,
 		CostVelocityMedium: 0.25,
 		QuotaCritical:      15.0,
@@ -373,9 +363,6 @@ func TestMergeThresholds_PartialOverride(t *testing.T) {
 	// Overridden int fields
 	if result.ContextDanger != 90 {
 		t.Errorf("ContextDanger should be overridden: expected 90, got %d", result.ContextDanger)
-	}
-	if result.SpeedFast != 100 {
-		t.Errorf("SpeedFast should be overridden: expected 100, got %d", result.SpeedFast)
 	}
 
 	// Overridden float64 fields
@@ -432,7 +419,7 @@ func TestLoadConfig_WithThresholds(t *testing.T) {
 	configPath := filepath.Join(configDir, "config.json")
 
 	// Write config with custom thresholds
-	content := `{"preset":"full","thresholds":{"context_danger":90,"speed_fast":100}}`
+	content := `{"preset":"full","thresholds":{"context_danger":90}}`
 	os.WriteFile(configPath, []byte(content), 0644)
 
 	cfg := LoadConfig()
@@ -440,9 +427,6 @@ func TestLoadConfig_WithThresholds(t *testing.T) {
 	// Verify overridden values
 	if cfg.Thresholds.ContextDanger != 90 {
 		t.Errorf("ContextDanger should be 90, got %d", cfg.Thresholds.ContextDanger)
-	}
-	if cfg.Thresholds.SpeedFast != 100 {
-		t.Errorf("SpeedFast should be 100, got %d", cfg.Thresholds.SpeedFast)
 	}
 
 	// Verify default values preserved
@@ -552,8 +536,6 @@ func TestValidateThresholds_CascadeToNegative(t *testing.T) {
 		CacheGood:          50,
 		WaitHigh:           60,
 		WaitMedium:         35,
-		SpeedFast:          60,
-		SpeedModerate:      30,
 		CostVelocityHigh:   0.50,
 		CostVelocityMedium: 0.10,
 		QuotaCritical:      10,
@@ -577,7 +559,7 @@ func TestValidateThresholds_CascadeToNegative(t *testing.T) {
 	}
 }
 
-func TestValidateThresholds_InvertedCacheWaitSpeed(t *testing.T) {
+func TestValidateThresholds_InvertedCacheWait(t *testing.T) {
 	th := Thresholds{
 		ContextDanger:      85,
 		ContextWarning:     70,
@@ -588,8 +570,6 @@ func TestValidateThresholds_InvertedCacheWaitSpeed(t *testing.T) {
 		CacheGood:          80, // inverted: good > excellent
 		WaitHigh:           30,
 		WaitMedium:         60, // inverted: medium > high
-		SpeedFast:          20,
-		SpeedModerate:      50, // inverted: moderate > fast
 		CostVelocityHigh:   0.50,
 		CostVelocityMedium: 0.10,
 		QuotaCritical:      10,
@@ -605,9 +585,6 @@ func TestValidateThresholds_InvertedCacheWaitSpeed(t *testing.T) {
 	if th.WaitMedium >= th.WaitHigh {
 		t.Errorf("WaitMedium (%d) should be < WaitHigh (%d)", th.WaitMedium, th.WaitHigh)
 	}
-	if th.SpeedModerate >= th.SpeedFast {
-		t.Errorf("SpeedModerate (%d) should be < SpeedFast (%d)", th.SpeedModerate, th.SpeedFast)
-	}
 }
 
 func TestValidateThresholds_UpperBoundClamping(t *testing.T) {
@@ -621,8 +598,6 @@ func TestValidateThresholds_UpperBoundClamping(t *testing.T) {
 		CacheGood:          150,
 		WaitHigh:           200,
 		WaitMedium:         150,
-		SpeedFast:          60,
-		SpeedModerate:      30,
 		CostVelocityHigh:   0.50,
 		CostVelocityMedium: 0.10,
 		QuotaCritical:      10,
@@ -670,8 +645,6 @@ func TestMergeThresholds_AllOverridden(t *testing.T) {
 		CacheGood:          60,
 		WaitHigh:           70,
 		WaitMedium:         40,
-		SpeedFast:          80,
-		SpeedModerate:      40,
 		CostVelocityHigh:   1.0,
 		CostVelocityMedium: 0.20,
 		QuotaCritical:      15,
@@ -708,12 +681,6 @@ func TestMergeThresholds_AllOverridden(t *testing.T) {
 	}
 	if result.WaitMedium != 40 {
 		t.Errorf("WaitMedium: expected 40, got %d", result.WaitMedium)
-	}
-	if result.SpeedFast != 80 {
-		t.Errorf("SpeedFast: expected 80, got %d", result.SpeedFast)
-	}
-	if result.SpeedModerate != 40 {
-		t.Errorf("SpeedModerate: expected 40, got %d", result.SpeedModerate)
 	}
 	if result.CostVelocityHigh != 1.0 {
 		t.Errorf("CostVelocityHigh: expected 1.0, got %.2f", result.CostVelocityHigh)
@@ -756,20 +723,5 @@ func TestValidateThresholds_QuotaCriticalHigh(t *testing.T) {
 	}
 	if th.QuotaHigh > 100 {
 		t.Errorf("QuotaHigh should not exceed 100, got %.1f", th.QuotaHigh)
-	}
-}
-
-func TestValidateThresholds_SpeedFastMinimum(t *testing.T) {
-	// SpeedFast=1 caused SpeedModerate equality (both=1).
-	// Now SpeedFast minimum is 2.
-	th := DefaultThresholds()
-	th.SpeedFast = 1
-	validateThresholds(&th)
-
-	if th.SpeedFast < 2 {
-		t.Errorf("SpeedFast should be clamped to minimum 2, got %d", th.SpeedFast)
-	}
-	if th.SpeedModerate >= th.SpeedFast {
-		t.Errorf("SpeedModerate (%d) should be < SpeedFast (%d)", th.SpeedModerate, th.SpeedFast)
 	}
 }

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -23,13 +23,6 @@ const (
 	// Below 35% = Green: minimal wait time
 )
 
-// Response speed thresholds (tokens/second)
-const (
-	SpeedFast     = 60 // Green: fast response
-	SpeedModerate = 30 // Yellow: moderate speed
-	// Below 30 = Orange: slow response
-)
-
 // Cost velocity thresholds ($/minute)
 const (
 	CostHigh   = 0.50 // Red: expensive session
@@ -56,9 +49,7 @@ const (
 	// Above 75% = Green: plenty remaining
 )
 
-// External operation timeouts and cache TTL
+// External operation timeouts
 const (
-	GitTimeout      = 1 * time.Second  // Git subprocess timeout
-	UsageCacheTTL   = 60 * time.Second // OAuth quota cache duration
-	UsageAPITimeout = 3 * time.Second  // OAuth API request timeout
+	GitTimeout = 1 * time.Second // Git subprocess timeout
 )

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -345,11 +345,8 @@ func TestIntegration_NormalMode(t *testing.T) {
 			json: jsonNormalSession,
 			cfg:  PresetConfig("full"),
 			usage: &UsageData{
-				RemainingPercent5h: 80.0,
-				RemainingPercent7d: 90.0,
-				ResetsAt5h:         futureTime,
-				ResetsAt7d:         futureTime.Add(48 * time.Hour),
-				FetchedAt:          time.Now().Unix(),
+				FiveHour: &UsageWindow{RemainingPercent: 80.0, ResetsAt: futureTime},
+				SevenDay: &UsageWindow{RemainingPercent: 90.0, ResetsAt: futureTime.Add(48 * time.Hour)},
 			},
 			wantMinLines: 2,
 			wantMaxLines: 4,
@@ -488,11 +485,8 @@ func TestIntegration_DangerMode(t *testing.T) {
 				Dirty:  false,
 			},
 			usage: &UsageData{
-				RemainingPercent5h: 25.0,
-				RemainingPercent7d: 40.0,
-				ResetsAt5h:         futureTime,
-				ResetsAt7d:         futureTime.Add(72 * time.Hour),
-				FetchedAt:          time.Now().Unix(),
+				FiveHour: &UsageWindow{RemainingPercent: 25.0, ResetsAt: futureTime},
+				SevenDay: &UsageWindow{RemainingPercent: 40.0, ResetsAt: futureTime.Add(72 * time.Hour)},
 			},
 			wantContains: []string{
 				"🔴",
@@ -630,7 +624,6 @@ func TestIntegration_MetricsComputedFromJSON(t *testing.T) {
 		json                    string
 		wantContextPercent      int
 		wantCacheEfficiencyMin  *int
-		wantResponseSpeedMin    *int
 		wantCostPerMinuteExists bool
 	}{
 		{
@@ -639,10 +632,6 @@ func TestIntegration_MetricsComputedFromJSON(t *testing.T) {
 			wantContextPercent: 42,
 			wantCacheEfficiencyMin: func() *int {
 				v := 30 // At least 30% cache efficiency
-				return &v
-			}(),
-			wantResponseSpeedMin: func() *int {
-				v := 120 // 8000 output tokens / 60s = 133 tok/s
 				return &v
 			}(),
 			wantCostPerMinuteExists: true,
@@ -655,10 +644,6 @@ func TestIntegration_MetricsComputedFromJSON(t *testing.T) {
 				v := 42 // 8000 cache / (10000 + 1000 + 8000) = 42%
 				return &v
 			}(),
-			wantResponseSpeedMin: func() *int {
-				v := 90 // 20000 output tokens / 200s = 100 tok/s
-				return &v
-			}(),
 			wantCostPerMinuteExists: true,
 		},
 		{
@@ -666,7 +651,6 @@ func TestIntegration_MetricsComputedFromJSON(t *testing.T) {
 			json:                    jsonFreshSession,
 			wantContextPercent:      0,
 			wantCacheEfficiencyMin:  nil,
-			wantResponseSpeedMin:    nil,
 			wantCostPerMinuteExists: false,
 		},
 		{
@@ -675,10 +659,6 @@ func TestIntegration_MetricsComputedFromJSON(t *testing.T) {
 			wantContextPercent: 85,
 			wantCacheEfficiencyMin: func() *int {
 				v := 25 // 5000 cache / (10000 + 5000 + 5000) = 25%
-				return &v
-			}(),
-			wantResponseSpeedMin: func() *int {
-				v := 9 // 1000 output / 100s = 10 tok/s
 				return &v
 			}(),
 			wantCostPerMinuteExists: true,
@@ -711,19 +691,6 @@ func TestIntegration_MetricsComputedFromJSON(t *testing.T) {
 			} else {
 				if m.CacheEfficiency != nil {
 					t.Errorf("CacheEfficiency: got %d, want nil", *m.CacheEfficiency)
-				}
-			}
-
-			// Verify response speed
-			if tt.wantResponseSpeedMin != nil {
-				if m.ResponseSpeed == nil {
-					t.Errorf("ResponseSpeed: got nil, want >= %d", *tt.wantResponseSpeedMin)
-				} else if *m.ResponseSpeed < *tt.wantResponseSpeedMin {
-					t.Errorf("ResponseSpeed: got %d, want >= %d", *m.ResponseSpeed, *tt.wantResponseSpeedMin)
-				}
-			} else {
-				if m.ResponseSpeed != nil {
-					t.Errorf("ResponseSpeed: got %d, want nil", *m.ResponseSpeed)
 				}
 			}
 
@@ -774,21 +741,17 @@ func TestIntegration_PriorityOrdering(t *testing.T) {
 	cfg := Config{
 		Preset: "full",
 		Features: FeatureToggles{
-			Account:       true,
-			Git:           true,
-			LineChanges:   true,
-			ResponseSpeed: true,
-			Quota:         true,
+			Account:     true,
+			Git:         true,
+			LineChanges: true,
+			Quota:       true,
 		},
 	}
 
 	git := &GitInfo{Branch: "feature", Dirty: false}
 	usage := &UsageData{
-		RemainingPercent5h: 80.0,
-		RemainingPercent7d: 90.0,
-		ResetsAt5h:         futureTime,
-		ResetsAt7d:         futureTime.Add(48 * time.Hour),
-		FetchedAt:          time.Now().Unix(),
+		FiveHour: &UsageWindow{RemainingPercent: 80.0, ResetsAt: futureTime},
+		SevenDay: &UsageWindow{RemainingPercent: 90.0, ResetsAt: futureTime.Add(48 * time.Hour)},
 	}
 	account := &AccountInfo{EmailAddress: "test@example.com"}
 
@@ -859,7 +822,7 @@ func TestIntegration_CustomThresholds(t *testing.T) {
 	customCfg.Thresholds.ContextWarning = 80
 
 	git := &GitInfo{Branch: "main", Dirty: true}
-	usage := &UsageData{RemainingPercent5h: 60.0, RemainingPercent7d: 80.0}
+	usage := &UsageData{FiveHour: &UsageWindow{RemainingPercent: 60.0}, SevenDay: &UsageWindow{RemainingPercent: 80.0}}
 	normalLines := Render(RenderContext{Data: &d, Metrics: m, Git: git, Usage: usage, Config: customCfg})
 
 	if len(normalLines) <= 2 {

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -6,7 +6,6 @@ type Metrics struct {
 	CacheEfficiency *int // nil if insufficient data
 	APIWaitRatio    *int // nil if duration=0
 	CostPerMinute   *float64
-	ResponseSpeed   *int // tokens/sec output speed
 }
 
 // ComputeMetrics calculates derived KPIs from raw session data.
@@ -20,7 +19,6 @@ func ComputeMetrics(d *StdinData) Metrics {
 	}
 	m.APIWaitRatio = calcAPIWaitRatio(&d.Cost)
 	m.CostPerMinute = calcCostPerMinute(&d.Cost)
-	m.ResponseSpeed = calcResponseSpeed(&d.Cost, &d.ContextWindow)
 	return m
 }
 
@@ -68,15 +66,5 @@ func calcCostPerMinute(c *Cost) *float64 {
 	}
 	minutes := float64(c.TotalDurationMS) / msPerMinute
 	v := c.TotalCostUSD / minutes
-	return &v
-}
-
-func calcResponseSpeed(c *Cost, cw *ContextWindow) *int {
-	if c.TotalAPIDurationMS == 0 || cw.TotalOutputTokens == 0 {
-		return nil
-	}
-	seconds := float64(c.TotalAPIDurationMS) / 1000.0
-	speed := float64(cw.TotalOutputTokens) / seconds
-	v := int(speed)
 	return &v
 }

--- a/internal/metrics_test.go
+++ b/internal/metrics_test.go
@@ -431,118 +431,6 @@ func TestCalcCostPerMinute(t *testing.T) {
 	}
 }
 
-func TestCalcResponseSpeed(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		cost *Cost
-		cw   *ContextWindow
-		want *int
-	}{
-		{
-			name: "normal calculation",
-			cost: &Cost{
-				TotalAPIDurationMS: 5000, // 5 seconds
-			},
-			cw: &ContextWindow{
-				TotalOutputTokens: 100,
-			},
-			want: intPtr(20), // 100 / 5.0 = 20 tok/s
-		},
-		{
-			name: "TotalAPIDurationMS zero returns nil",
-			cost: &Cost{
-				TotalAPIDurationMS: 0,
-			},
-			cw: &ContextWindow{
-				TotalOutputTokens: 100,
-			},
-			want: nil,
-		},
-		{
-			name: "TotalOutputTokens zero returns nil",
-			cost: &Cost{
-				TotalAPIDurationMS: 5000,
-			},
-			cw: &ContextWindow{
-				TotalOutputTokens: 0,
-			},
-			want: nil,
-		},
-		{
-			name: "both zero returns nil",
-			cost: &Cost{
-				TotalAPIDurationMS: 0,
-			},
-			cw: &ContextWindow{
-				TotalOutputTokens: 0,
-			},
-			want: nil,
-		},
-		{
-			name: "large values",
-			cost: &Cost{
-				TotalAPIDurationMS: 10000, // 10 seconds
-			},
-			cw: &ContextWindow{
-				TotalOutputTokens: 500,
-			},
-			want: intPtr(50), // 500 / 10.0 = 50 tok/s
-		},
-		{
-			name: "fast response (100 tok/s)",
-			cost: &Cost{
-				TotalAPIDurationMS: 1000, // 1 second
-			},
-			cw: &ContextWindow{
-				TotalOutputTokens: 100,
-			},
-			want: intPtr(100),
-		},
-		{
-			name: "slow response (1 tok/s)",
-			cost: &Cost{
-				TotalAPIDurationMS: 10000, // 10 seconds
-			},
-			cw: &ContextWindow{
-				TotalOutputTokens: 10,
-			},
-			want: intPtr(1),
-		},
-		{
-			name: "truncation test (fractional tok/s)",
-			cost: &Cost{
-				TotalAPIDurationMS: 3000, // 3 seconds
-			},
-			cw: &ContextWindow{
-				TotalOutputTokens: 100,
-			},
-			want: intPtr(33), // 100 / 3.0 = 33.333... → 33
-		},
-		{
-			name: "very fast (sub-second)",
-			cost: &Cost{
-				TotalAPIDurationMS: 500, // 0.5 seconds
-			},
-			cw: &ContextWindow{
-				TotalOutputTokens: 100,
-			},
-			want: intPtr(200), // 100 / 0.5 = 200 tok/s
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := calcResponseSpeed(tt.cost, tt.cw)
-			if !intPtrEq(got, tt.want) {
-				t.Errorf("calcResponseSpeed() = %s, want %s", ptrIntToString(got), ptrIntToString(tt.want))
-			}
-		})
-	}
-}
-
 func TestComputeMetrics(t *testing.T) {
 	t.Parallel()
 
@@ -575,7 +463,6 @@ func TestComputeMetrics(t *testing.T) {
 				CacheEfficiency: intPtr(50),    // 15000*100/(10000+5000+15000) = 50
 				APIWaitRatio:    intPtr(4),     // 5000*100/120000 = 4
 				CostPerMinute:   floatPtr(1.2), // 2.4 / 2 = 1.2
-				ResponseSpeed:   intPtr(20),    // 100 / 5.0 = 20
 			},
 		},
 		{
@@ -598,7 +485,6 @@ func TestComputeMetrics(t *testing.T) {
 				CacheEfficiency: nil,       // CurrentUsage is nil
 				APIWaitRatio:    intPtr(0), // 0 API duration
 				CostPerMinute:   nil,       // < 60000ms
-				ResponseSpeed:   nil,       // API duration is 0
 			},
 		},
 		{
@@ -621,7 +507,6 @@ func TestComputeMetrics(t *testing.T) {
 				CacheEfficiency: nil,
 				APIWaitRatio:    nil,
 				CostPerMinute:   nil,
-				ResponseSpeed:   nil,
 			},
 		},
 		{
@@ -648,7 +533,6 @@ func TestComputeMetrics(t *testing.T) {
 				CacheEfficiency: intPtr(77),    // 135000*100/(30000+10000+135000) ≈ 77
 				APIWaitRatio:    intPtr(15),    // 45000*100/300000 = 15
 				CostPerMinute:   floatPtr(3.0), // 15.0 / 5 = 3.0
-				ResponseSpeed:   intPtr(11),    // 500 / 45.0 ≈ 11
 			},
 		},
 		{
@@ -675,7 +559,6 @@ func TestComputeMetrics(t *testing.T) {
 				CacheEfficiency: intPtr(100),   // only cache_read
 				APIWaitRatio:    intPtr(100),   // 100% API time
 				CostPerMinute:   floatPtr(5.0), // 5.0 / 1 = 5.0
-				ResponseSpeed:   intPtr(2),     // 120 / 60.0 = 2
 			},
 		},
 	}
@@ -697,9 +580,6 @@ func TestComputeMetrics(t *testing.T) {
 			}
 			if !floatPtrEq(got.CostPerMinute, tt.want.CostPerMinute) {
 				t.Errorf("CostPerMinute = %v, want %v", ptrFloatToString(got.CostPerMinute), ptrFloatToString(tt.want.CostPerMinute))
-			}
-			if !intPtrEq(got.ResponseSpeed, tt.want.ResponseSpeed) {
-				t.Errorf("ResponseSpeed = %v, want %v", ptrIntToString(got.ResponseSpeed), ptrIntToString(tt.want.ResponseSpeed))
 			}
 		})
 	}

--- a/internal/render.go
+++ b/internal/render.go
@@ -2,7 +2,9 @@ package internal
 
 import (
 	"fmt"
+	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -61,8 +63,10 @@ func renderNormalMode(rc RenderContext) []string {
 	if cfg.Features.Git && git != nil && git.Branch != "" {
 		line1 = append(line1, renderGitCompact(git))
 	}
-	if cfg.Features.ResponseSpeed && m.ResponseSpeed != nil && *m.ResponseSpeed > 0 {
-		line1 = append(line1, renderResponseSpeed(*m.ResponseSpeed, t))
+	if cfg.Features.OutputTokens {
+		if s := renderOutputTokens(d.ContextWindow.CurrentUsage); s != "" {
+			line1 = append(line1, s)
+		}
 	}
 	if costStr := renderCost(d.Cost.TotalCostUSD, t); costStr != "" {
 		line1 = append(line1, costStr)
@@ -74,8 +78,12 @@ func renderNormalMode(rc RenderContext) []string {
 	if hasQuotaBars {
 		line2 = make([]string, 0, 3)
 		line2 = append(line2, renderContextBar(m.ContextPercent, d.ContextWindow, t))
-		line2 = append(line2, renderQuotaBar(usage.RemainingPercent5h, usage.ResetsAt5h, "5h", t))
-		line2 = append(line2, renderQuotaBar(usage.RemainingPercent7d, usage.ResetsAt7d, "7d", t))
+		if s := renderQuotaWindow(usage.FiveHour, "5h", t); s != "" {
+			line2 = append(line2, s)
+		}
+		if s := renderQuotaWindow(usage.SevenDay, "7d", t); s != "" {
+			line2 = append(line2, s)
+		}
 	}
 
 	// Line 3: line changes | cache | wait | cost velocity (+ vim/agent conditionally)
@@ -100,6 +108,31 @@ func renderNormalMode(rc RenderContext) []string {
 	if cfg.Features.AgentName && d.Agent != nil && d.Agent.Name != "" {
 		line3 = append(line3, renderAgentCompact(d.Agent.Name))
 	}
+	if cfg.Features.Effort {
+		if s := renderEffort(d.Effort); s != "" {
+			line3 = append(line3, s)
+		}
+	}
+	if cfg.Features.Thinking {
+		if s := renderThinking(d.Thinking); s != "" {
+			line3 = append(line3, s)
+		}
+	}
+	if cfg.Features.SessionName {
+		if s := renderSessionName(d.SessionName); s != "" {
+			line3 = append(line3, s)
+		}
+	}
+	if cfg.Features.PullRequest {
+		if s := renderPR(d.PR); s != "" {
+			line3 = append(line3, s)
+		}
+	}
+	if cfg.Features.Worktree {
+		if s := renderWorktreeName(d.Worktree); s != "" {
+			line3 = append(line3, s)
+		}
+	}
 	if v := renderVersion(d.Version); v != "" {
 		line3 = append(line3, v)
 	}
@@ -113,7 +146,7 @@ func renderNormalMode(rc RenderContext) []string {
 		agentStr = renderAgents(tools.Agents)
 	}
 
-	toolBudget := maxToolLineWidth
+	toolBudget := terminalColumns()
 	if agentStr != "" {
 		toolBudget -= visibleLen(agentStr) + 3 // 3 for " | " separator
 	}
@@ -149,11 +182,11 @@ func renderDangerMode(rc RenderContext) []string {
 	line1 = append(line1, renderContextBarDanger(m.ContextPercent, d.ContextWindow, d.Cost.TotalDurationMS, t))
 
 	if usage != nil {
-		if usage.RemainingPercent5h > 0 || !usage.ResetsAt5h.IsZero() {
-			line1 = append(line1, renderQuotaBar(usage.RemainingPercent5h, usage.ResetsAt5h, "5h", t))
+		if s := renderQuotaWindow(usage.FiveHour, "5h", t); s != "" {
+			line1 = append(line1, s)
 		}
-		if usage.RemainingPercent7d > 0 || !usage.ResetsAt7d.IsZero() {
-			line1 = append(line1, renderQuotaBar(usage.RemainingPercent7d, usage.ResetsAt7d, "7d", t))
+		if s := renderQuotaWindow(usage.SevenDay, "7d", t); s != "" {
+			line1 = append(line1, s)
 		}
 	}
 
@@ -178,10 +211,6 @@ func renderDangerMode(rc RenderContext) []string {
 
 	if m.CacheEfficiency != nil {
 		line2 = append(line2, renderCacheEfficiencyCompact(*m.CacheEfficiency, t))
-	}
-
-	if m.ResponseSpeed != nil && *m.ResponseSpeed > 0 {
-		line2 = append(line2, renderResponseSpeed(*m.ResponseSpeed, t))
 	}
 
 	if costStr := renderCost(d.Cost.TotalCostUSD, t); costStr != "" {
@@ -452,17 +481,14 @@ func renderCostVelocityLabeled(perMin float64, t Thresholds) string {
 	return fmt.Sprintf("%sCost:%s$%.2f/m%s", grey, color, perMin, Reset)
 }
 
-func renderResponseSpeed(tokPerSec int, t Thresholds) string {
-	var color string
-	switch {
-	case tokPerSec >= t.SpeedFast:
-		color = green // fast
-	case tokPerSec >= t.SpeedModerate:
-		color = yellow // moderate
-	default:
-		color = orange // slow
+// renderOutputTokens shows the output token count of the current/last API
+// response — a truthful replacement for the removed tok/s speed metric.
+// Returns "" when there is nothing to show.
+func renderOutputTokens(cu *CurrentUsage) string {
+	if cu == nil || cu.OutputTokens <= 0 {
+		return ""
 	}
-	return fmt.Sprintf("%s%dtok/s%s", color, tokPerSec, Reset)
+	return grey + "Out:" + formatTokenCount(cu.OutputTokens) + Reset
 }
 
 func renderVimCompact(mode string) string {
@@ -488,6 +514,69 @@ func renderVersion(version string) string {
 		return ""
 	}
 	return grey + "v" + version + Reset
+}
+
+// Optional CC 2.1 field renderers. Each returns "" when its source is absent so
+// callers append conditionally (OCP: add a field by adding a function).
+
+func renderEffort(e *Effort) string {
+	if e == nil || e.Level == "" {
+		return ""
+	}
+	return dim + "E:" + e.Level + Reset
+}
+
+func renderThinking(th *Thinking) string {
+	if th == nil || !th.Enabled {
+		return ""
+	}
+	return cyan + "Think" + Reset
+}
+
+func renderSessionName(name string) string {
+	if name == "" {
+		return ""
+	}
+	runes := []rune(name)
+	if len(runes) > 12 {
+		name = string(runes[:12])
+	}
+	return dim + name + Reset
+}
+
+func renderPR(pr *PullRequest) string {
+	if pr == nil || pr.Number == 0 {
+		return ""
+	}
+	s := fmt.Sprintf("%sPR#%d", cyan, pr.Number)
+	if pr.ReviewState != "" {
+		s += " " + pr.ReviewState
+	}
+	return s + Reset
+}
+
+func renderWorktreeName(wt *Worktree) string {
+	if wt == nil || wt.Name == "" {
+		return ""
+	}
+	name := wt.Name
+	runes := []rune(name)
+	if len(runes) > 10 {
+		name = string(runes[:10])
+	}
+	return cyan + "wt:" + name + Reset
+}
+
+// terminalColumns returns the terminal width from the COLUMNS env var that
+// Claude Code provides to statusline commands (v2.1.153+), clamped to a sane
+// range. Falls back to maxToolLineWidth when unset/invalid (tests, non-Claude
+// execution) so behavior is unchanged where COLUMNS is absent.
+func terminalColumns() int {
+	n, err := strconv.Atoi(os.Getenv("COLUMNS"))
+	if err != nil {
+		return maxToolLineWidth
+	}
+	return min(max(n, 40), 240)
 }
 
 func renderAgentCompact(name string) string {
@@ -622,6 +711,16 @@ func formatTokenCount(tokens int) string {
 	return fmt.Sprintf("%.0fK", float64(tokens)/1000.0)
 }
 
+// renderQuotaWindow renders one quota window, or "" when the window is absent.
+// Single code path for 5h/7d across normal and danger modes (DRY); presence is
+// the pointer, never a zero value.
+func renderQuotaWindow(w *UsageWindow, label string, t Thresholds) string {
+	if w == nil {
+		return ""
+	}
+	return renderQuotaBar(w.RemainingPercent, w.ResetsAt, label, t)
+}
+
 func renderQuotaBar(remainPct float64, resetTime time.Time, label string, t Thresholds) string {
 	const width = 10
 	filled := max(0, min(int(remainPct)*width/100, width))
@@ -630,13 +729,47 @@ func renderQuotaBar(remainPct float64, resetTime time.Time, label string, t Thre
 	color := quotaColor(remainPct, t)
 	now := time.Now()
 	var until string
+	var windowLen time.Duration
 	if label == "5h" {
 		until = formatTimeUntilWithMinutes(now, resetTime)
+		windowLen = 5 * time.Hour
 	} else {
 		until = formatTimeUntil(now, resetTime)
+		windowLen = 7 * 24 * time.Hour
 	}
 
-	return fmt.Sprintf("%s%s%s %3.0f%% (%s/%s)", color, bar, Reset, remainPct, until, label)
+	marker := quotaPaceMarker(remainPct, resetTime, now, windowLen)
+	return fmt.Sprintf("%s%s%s %3.0f%% (%s/%s)%s", color, bar, Reset, remainPct, until, label, marker)
+}
+
+// quotaPaceMarker returns a "🔥" warning when the window is projected to be
+// exhausted before it resets — i.e. consumption is ahead of the even time-based
+// pace. Pure function of a single stdin snapshot (no history needed): it
+// compares the average burn rate so far against the rate that would last until
+// reset. Returns "" when on pace, already exhausted, or signal is too weak.
+func quotaPaceMarker(remainPct float64, resetsAt, now time.Time, windowLen time.Duration) string {
+	if resetsAt.IsZero() || remainPct <= 0 || windowLen <= 0 {
+		return ""
+	}
+	timeToReset := resetsAt.Sub(now)
+	if timeToReset <= 0 {
+		return ""
+	}
+	elapsed := windowLen - timeToReset
+	if elapsed < windowLen/20 { // need >=5% elapsed to project meaningfully
+		return ""
+	}
+	used := 100 - remainPct
+	if used <= 0 {
+		return ""
+	}
+	// Ahead of pace iff time-to-exhaust < time-to-reset. Cross-multiplied to
+	// avoid float-duration construction: remainPct/burn < timeToReset, where
+	// burn = used/elapsed  =>  remainPct*elapsed < used*timeToReset.
+	if remainPct*elapsed.Seconds() < used*timeToReset.Seconds() {
+		return boldRed + "🔥" + Reset
+	}
+	return ""
 }
 
 func formatTimeUntil(now, target time.Time) string {

--- a/internal/render_test.go
+++ b/internal/render_test.go
@@ -1,8 +1,10 @@
 package internal
 
 import (
+	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRenderModelBadge(t *testing.T) {
@@ -545,33 +547,6 @@ func TestRenderAPIRatioLabeled(t *testing.T) {
 	}
 }
 
-func TestRenderResponseSpeed(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		speed     int
-		wantColor string
-	}{
-		{"fast >=60 green", 60, green},
-		{"moderate >=30 yellow", 30, yellow},
-		{"slow <30 orange", 29, orange},
-		{"very fast", 100, green},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := renderResponseSpeed(tt.speed, DefaultThresholds())
-			if !strings.Contains(got, tt.wantColor) {
-				t.Errorf("renderResponseSpeed(%d) missing color %q in %q", tt.speed, tt.wantColor, got)
-			}
-			if !strings.Contains(got, "tok/s") {
-				t.Errorf("renderResponseSpeed(%d) missing 'tok/s' in %q", tt.speed, got)
-			}
-		})
-	}
-}
-
 func TestRenderCostVelocityLabeled(t *testing.T) {
 	t.Parallel()
 
@@ -933,7 +908,7 @@ func TestRenderWithConfig(t *testing.T) {
 
 	t.Run("cost-focused preset shows quota metrics", func(t *testing.T) {
 		cfg := PresetConfig("cost-focused")
-		usage := &UsageData{RemainingPercent5h: 80.0, RemainingPercent7d: 90.0}
+		usage := &UsageData{FiveHour: &UsageWindow{RemainingPercent: 80.0}, SevenDay: &UsageWindow{RemainingPercent: 90.0}}
 		lines := Render(RenderContext{Data: d, Metrics: m, Usage: usage, Account: account, Config: cfg})
 		// cost-focused with usage: L1 (model+context size+cost+dur) + L2 (3 bars) = 2+ lines
 		if len(lines) < 2 {
@@ -943,6 +918,180 @@ func TestRenderWithConfig(t *testing.T) {
 		output := strings.Join(lines, " ")
 		if !strings.Contains(output, "user@example.com") {
 			t.Error("cost-focused preset should show account")
+		}
+	})
+}
+
+func TestTerminalColumns(t *testing.T) {
+	// Not parallel: mutates the COLUMNS environment variable.
+	tests := []struct {
+		name string
+		env  string
+		set  bool
+		want int
+	}{
+		{"unset falls back to 80", "", false, 80},
+		{"invalid falls back to 80", "abc", true, 80},
+		{"empty falls back to 80", "", true, 80},
+		{"narrow 60", "60", true, 60},
+		{"wide 120", "120", true, 120},
+		{"below floor clamps to 40", "20", true, 40},
+		{"above ceiling clamps to 240", "999", true, 240},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv("COLUMNS", tt.env)
+			} else {
+				_ = os.Unsetenv("COLUMNS")
+			}
+			if got := terminalColumns(); got != tt.want {
+				t.Errorf("terminalColumns() with COLUMNS=%q = %d, want %d", tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOptionalFieldRenderers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("absent sources render empty", func(t *testing.T) {
+		t.Parallel()
+		if got := renderEffort(nil); got != "" {
+			t.Errorf("renderEffort(nil) = %q, want empty", got)
+		}
+		if got := renderThinking(nil); got != "" {
+			t.Errorf("renderThinking(nil) = %q, want empty", got)
+		}
+		if got := renderThinking(&Thinking{Enabled: false}); got != "" {
+			t.Errorf("renderThinking(disabled) = %q, want empty", got)
+		}
+		if got := renderSessionName(""); got != "" {
+			t.Errorf("renderSessionName(\"\") = %q, want empty", got)
+		}
+		if got := renderPR(nil); got != "" {
+			t.Errorf("renderPR(nil) = %q, want empty", got)
+		}
+		if got := renderPR(&PullRequest{Number: 0}); got != "" {
+			t.Errorf("renderPR(0) = %q, want empty", got)
+		}
+		if got := renderWorktreeName(nil); got != "" {
+			t.Errorf("renderWorktreeName(nil) = %q, want empty", got)
+		}
+	})
+
+	t.Run("present sources render labels", func(t *testing.T) {
+		t.Parallel()
+		if got := renderEffort(&Effort{Level: "high"}); !strings.Contains(got, "E:high") {
+			t.Errorf("renderEffort = %q, want E:high", got)
+		}
+		if got := renderThinking(&Thinking{Enabled: true}); !strings.Contains(got, "Think") {
+			t.Errorf("renderThinking = %q, want Think", got)
+		}
+		if got := renderSessionName("my-session"); !strings.Contains(got, "my-session") {
+			t.Errorf("renderSessionName = %q, want my-session", got)
+		}
+		if got := renderPR(&PullRequest{Number: 1234, ReviewState: "pending"}); !strings.Contains(got, "PR#1234") || !strings.Contains(got, "pending") {
+			t.Errorf("renderPR = %q, want PR#1234 pending", got)
+		}
+		if got := renderPR(&PullRequest{Number: 9}); !strings.Contains(got, "PR#9") {
+			t.Errorf("renderPR(no review_state) = %q, want PR#9", got)
+		}
+		if got := renderWorktreeName(&Worktree{Name: "feat"}); !strings.Contains(got, "wt:feat") {
+			t.Errorf("renderWorktreeName = %q, want wt:feat", got)
+		}
+	})
+
+	t.Run("truncation", func(t *testing.T) {
+		t.Parallel()
+		if got := renderSessionName("0123456789ABCDEF"); strings.Contains(got, "ABCDEF") {
+			t.Errorf("renderSessionName should truncate at 12 runes: %q", got)
+		}
+		if got := renderWorktreeName(&Worktree{Name: "0123456789XYZ"}); strings.Contains(got, "XYZ") {
+			t.Errorf("renderWorktreeName should truncate at 10 runes: %q", got)
+		}
+	})
+
+	t.Run("toggles gate rendering in normal mode", func(t *testing.T) {
+		t.Parallel()
+		d := &StdinData{
+			Model:         Model{DisplayName: "Claude Sonnet 4.5"},
+			ContextWindow: ContextWindow{ContextWindowSize: 200000, UsedPercentage: floatPtr(40)},
+			Cost:          Cost{TotalDurationMS: 120000, TotalCostUSD: 1.0},
+			Effort:        &Effort{Level: "high"},
+			PR:            &PullRequest{Number: 7},
+		}
+		m := Metrics{ContextPercent: 40}
+
+		// Default preset: optional renderers off -> not shown.
+		off := strings.Join(Render(RenderContext{Data: d, Metrics: m, Config: PresetConfig("full")}), " ")
+		if strings.Contains(off, "E:high") || strings.Contains(off, "PR#7") {
+			t.Errorf("optional fields must be off by default: %q", off)
+		}
+
+		// Explicitly enabled -> shown.
+		cfg := PresetConfig("full")
+		cfg.Features.Effort = true
+		cfg.Features.PullRequest = true
+		on := strings.Join(Render(RenderContext{Data: d, Metrics: m, Config: cfg}), " ")
+		if !strings.Contains(on, "E:high") {
+			t.Errorf("Effort should render when enabled: %q", on)
+		}
+		if !strings.Contains(on, "PR#7") {
+			t.Errorf("PR should render when enabled: %q", on)
+		}
+	})
+}
+
+// TestRenderQuotaWindowPresence guards against the regression where an absent
+// rate-limit window rendered a fake "0% (?/...)" bar. Presence is the pointer.
+func TestRenderQuotaWindowPresence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil window renders nothing", func(t *testing.T) {
+		t.Parallel()
+		if got := renderQuotaWindow(nil, "5h", DefaultThresholds()); got != "" {
+			t.Errorf("renderQuotaWindow(nil) = %q, want empty", got)
+		}
+	})
+
+	t.Run("present window renders its label", func(t *testing.T) {
+		t.Parallel()
+		got := renderQuotaWindow(&UsageWindow{RemainingPercent: 80}, "5h", DefaultThresholds())
+		if !strings.Contains(got, "5h)") {
+			t.Errorf("renderQuotaWindow() = %q, want it to contain 5h label", got)
+		}
+	})
+
+	d := &StdinData{
+		Model:         Model{DisplayName: "Claude Sonnet 4.5"},
+		ContextWindow: ContextWindow{ContextWindowSize: 200000, UsedPercentage: floatPtr(40)},
+		Cost:          Cost{TotalDurationMS: 120000, TotalCostUSD: 1.0},
+	}
+	m := Metrics{ContextPercent: 40}
+	cfg := PresetConfig("full")
+
+	t.Run("only 5h present: 7d bar absent, no fake bar", func(t *testing.T) {
+		t.Parallel()
+		usage := &UsageData{FiveHour: &UsageWindow{RemainingPercent: 80}}
+		out := strings.Join(Render(RenderContext{Data: d, Metrics: m, Usage: usage, Config: cfg}), " ")
+		if !strings.Contains(out, "5h)") {
+			t.Errorf("expected 5h bar in output: %q", out)
+		}
+		if strings.Contains(out, "7d)") {
+			t.Errorf("absent 7d window must not render a bar: %q", out)
+		}
+	})
+
+	t.Run("only 7d present: 5h bar absent", func(t *testing.T) {
+		t.Parallel()
+		usage := &UsageData{SevenDay: &UsageWindow{RemainingPercent: 90}}
+		out := strings.Join(Render(RenderContext{Data: d, Metrics: m, Usage: usage, Config: cfg}), " ")
+		if !strings.Contains(out, "7d)") {
+			t.Errorf("expected 7d bar in output: %q", out)
+		}
+		if strings.Contains(out, "5h)") {
+			t.Errorf("absent 5h window must not render a bar: %q", out)
 		}
 	})
 }
@@ -1199,7 +1348,6 @@ func TestRenderNormalMode_AllLinesPresent(t *testing.T) {
 	cache := 80
 	apiRatio := 30
 	costPerMin := 0.05
-	speed := 100
 
 	d := &StdinData{
 		Model:         Model{DisplayName: "Claude Sonnet 4.5"},
@@ -1213,7 +1361,6 @@ func TestRenderNormalMode_AllLinesPresent(t *testing.T) {
 		CacheEfficiency: &cache,
 		APIWaitRatio:    &apiRatio,
 		CostPerMinute:   &costPerMin,
-		ResponseSpeed:   &speed,
 	}
 	git := &GitInfo{Branch: "main", Dirty: true}
 	tools := &ToolInfo{
@@ -1221,7 +1368,7 @@ func TestRenderNormalMode_AllLinesPresent(t *testing.T) {
 		Agents: []string{"coder", "tester"},
 	}
 	account := &AccountInfo{EmailAddress: "test@example.com"}
-	usage := &UsageData{RemainingPercent5h: 60.0}
+	usage := &UsageData{FiveHour: &UsageWindow{RemainingPercent: 60.0}}
 
 	cfg := DefaultConfig() // All features enabled
 
@@ -1255,7 +1402,6 @@ func TestRenderDangerMode_Full(t *testing.T) {
 
 	cache := 70
 	costPerMin := 0.25
-	speed := 80
 
 	d := &StdinData{
 		Model: Model{DisplayName: "Claude Opus 4"},
@@ -1274,10 +1420,9 @@ func TestRenderDangerMode_Full(t *testing.T) {
 		ContextPercent:  90,
 		CacheEfficiency: &cache,
 		CostPerMinute:   &costPerMin,
-		ResponseSpeed:   &speed,
 	}
 	git := &GitInfo{Branch: "feature", Dirty: true}
-	usage := &UsageData{RemainingPercent5h: 40.0, RemainingPercent7d: 70.0}
+	usage := &UsageData{FiveHour: &UsageWindow{RemainingPercent: 40.0}, SevenDay: &UsageWindow{RemainingPercent: 70.0}}
 
 	lines := renderDangerMode(RenderContext{Data: d, Metrics: m, Git: git, Usage: usage, Config: Config{Thresholds: DefaultThresholds()}})
 
@@ -1323,9 +1468,6 @@ func TestRenderDangerMode_Full(t *testing.T) {
 	}
 	if !strings.Contains(line2, "C70%") {
 		t.Errorf("L2 missing cache efficiency: %q", line2)
-	}
-	if !strings.Contains(line2, "80tok/s") {
-		t.Errorf("L2 missing speed: %q", line2)
 	}
 	// Cost per hour (0.25 * 60 = 15.0/h)
 	if !strings.Contains(line2, "15.0/h") {
@@ -1395,7 +1537,7 @@ func TestRenderDangerMode_WithQuota(t *testing.T) {
 		Cost:          Cost{TotalDurationMS: 60000},
 	}
 	m := Metrics{ContextPercent: 92}
-	usage := &UsageData{RemainingPercent5h: 15.0, RemainingPercent7d: 80.0}
+	usage := &UsageData{FiveHour: &UsageWindow{RemainingPercent: 15.0}, SevenDay: &UsageWindow{RemainingPercent: 80.0}}
 
 	lines := renderDangerMode(RenderContext{Data: d, Metrics: m, Usage: usage, Config: Config{Thresholds: DefaultThresholds()}})
 
@@ -1558,45 +1700,11 @@ func TestContextColor_CustomThresholds(t *testing.T) {
 	}
 }
 
-func TestRenderResponseSpeed_CustomThresholds(t *testing.T) {
-	t.Parallel()
-
-	customThresholds := DefaultThresholds()
-	customThresholds.SpeedFast = 100
-	customThresholds.SpeedModerate = 50
-
-	tests := []struct {
-		name      string
-		speed     int
-		wantColor string
-	}{
-		{"60 is yellow (below fast=100, above moderate=50)", 60, yellow},
-		{"100 is green (at fast)", 100, green},
-		{"49 is orange (below moderate=50)", 49, orange},
-		{"101 is green (above fast)", 101, green},
-		{"50 is yellow (at moderate)", 50, yellow},
-		{"20 is orange (below moderate)", 20, orange},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := renderResponseSpeed(tt.speed, customThresholds)
-			if !strings.Contains(got, tt.wantColor) {
-				t.Errorf("renderResponseSpeed(%d, custom) missing color %q in %q", tt.speed, tt.wantColor, got)
-			}
-			if !strings.Contains(got, "tok/s") {
-				t.Errorf("renderResponseSpeed(%d, custom) missing 'tok/s' in %q", tt.speed, got)
-			}
-		})
-	}
-}
-
 func TestRender_CustomDangerThreshold(t *testing.T) {
 	t.Parallel()
 
 	cache := 80
 	apiRatio := 35
-	speed := 60
 	d := &StdinData{
 		Model:         Model{DisplayName: "Sonnet"},
 		ContextWindow: ContextWindow{ContextWindowSize: 200000},
@@ -1606,7 +1714,7 @@ func TestRender_CustomDangerThreshold(t *testing.T) {
 	}
 	git := &GitInfo{Branch: "main", Dirty: true}
 	account := &AccountInfo{EmailAddress: "test@example.com"}
-	usage := &UsageData{RemainingPercent5h: 60.0, RemainingPercent7d: 80.0}
+	usage := &UsageData{FiveHour: &UsageWindow{RemainingPercent: 60.0}, SevenDay: &UsageWindow{RemainingPercent: 80.0}}
 	cfg := DefaultConfig()
 	cfg.Thresholds.ContextDanger = 90
 
@@ -1615,7 +1723,6 @@ func TestRender_CustomDangerThreshold(t *testing.T) {
 			ContextPercent:  87,
 			CacheEfficiency: &cache,
 			APIWaitRatio:    &apiRatio,
-			ResponseSpeed:   &speed,
 		}
 		lines := Render(RenderContext{Data: d, Metrics: m, Git: git, Usage: usage, Account: account, Config: cfg})
 
@@ -1848,4 +1955,86 @@ func TestRenderContextBar_CustomThresholdIcons(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRenderOutputTokens(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil cu returns empty", func(t *testing.T) {
+		t.Parallel()
+		if got := renderOutputTokens(nil); got != "" {
+			t.Errorf("renderOutputTokens(nil) = %q, want empty", got)
+		}
+	})
+
+	t.Run("zero OutputTokens returns empty", func(t *testing.T) {
+		t.Parallel()
+		cu := &CurrentUsage{OutputTokens: 0}
+		if got := renderOutputTokens(cu); got != "" {
+			t.Errorf("renderOutputTokens(0) = %q, want empty", got)
+		}
+	})
+
+	t.Run("non-zero OutputTokens returns non-empty containing Out:", func(t *testing.T) {
+		t.Parallel()
+		cu := &CurrentUsage{OutputTokens: 1234}
+		got := renderOutputTokens(cu)
+		if got == "" {
+			t.Fatal("renderOutputTokens(1234) = empty, want non-empty")
+		}
+		if !strings.Contains(got, "Out:") {
+			t.Errorf("renderOutputTokens(1234) = %q, want to contain 'Out:'", got)
+		}
+	})
+}
+
+func TestQuotaPaceMarker(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	windowLen := 5 * time.Hour
+
+	t.Run("zero resetsAt returns empty", func(t *testing.T) {
+		t.Parallel()
+		got := quotaPaceMarker(80, time.Time{}, now, windowLen)
+		if got != "" {
+			t.Errorf("quotaPaceMarker(zero resetsAt) = %q, want empty", got)
+		}
+	})
+
+	t.Run("on pace returns empty", func(t *testing.T) {
+		t.Parallel()
+		// 5h window, resetsAt = now+4h => elapsed=1h, remainPct=90, used=10
+		// remainPct*elapsed = 90*3600 = 324000
+		// used*ttr = 10*14400 = 144000
+		// 324000 < 144000 is false => on pace => ""
+		resetsAt := now.Add(4 * time.Hour)
+		got := quotaPaceMarker(90, resetsAt, now, windowLen)
+		if got != "" {
+			t.Errorf("quotaPaceMarker(on pace) = %q, want empty", got)
+		}
+	})
+
+	t.Run("ahead of pace returns fire emoji", func(t *testing.T) {
+		t.Parallel()
+		// 5h window, resetsAt = now+1h => elapsed=4h, remainPct=10, used=90
+		// remainPct*elapsed = 10*14400 = 144000
+		// used*ttr = 90*3600 = 324000
+		// 144000 < 324000 is true => ahead of pace => 🔥
+		resetsAt := now.Add(1 * time.Hour)
+		got := quotaPaceMarker(10, resetsAt, now, windowLen)
+		if !strings.Contains(got, "🔥") {
+			t.Errorf("quotaPaceMarker(ahead of pace) = %q, want to contain '🔥'", got)
+		}
+	})
+
+	t.Run("too early guard returns empty", func(t *testing.T) {
+		t.Parallel()
+		// 5h window, resetsAt = now+4h59m => elapsed=1m < windowLen/20=15m => ""
+		resetsAt := now.Add(4*time.Hour + 59*time.Minute)
+		got := quotaPaceMarker(95, resetsAt, now, windowLen)
+		if got != "" {
+			t.Errorf("quotaPaceMarker(too early) = %q, want empty", got)
+		}
+	})
 }

--- a/internal/types.go
+++ b/internal/types.go
@@ -4,8 +4,10 @@ import "strings"
 
 // StdinData represents the top-level JSON structure piped by Claude Code every ~300ms.
 // It contains session metrics, context window usage, cost data, and workspace information.
+// Field set tracks the Claude Code 2.1 statusline schema (https://code.claude.com/docs/en/statusline).
 type StdinData struct {
 	SessionID         string        `json:"session_id"`
+	SessionName       string        `json:"session_name"`
 	TranscriptPath    string        `json:"transcript_path"`
 	CWD               string        `json:"cwd"`
 	Version           string        `json:"version"`
@@ -17,6 +19,11 @@ type StdinData struct {
 	OutputStyle       *OutputStyle  `json:"output_style"`
 	Vim               *Vim          `json:"vim"`
 	Agent             *Agent        `json:"agent"`
+	Effort            *Effort       `json:"effort"`
+	Thinking          *Thinking     `json:"thinking"`
+	RateLimits        *RateLimits   `json:"rate_limits"`
+	PR                *PullRequest  `json:"pr"`
+	Worktree          *Worktree     `json:"worktree"`
 }
 
 // Model represents the AI model being used for the session.
@@ -27,8 +34,19 @@ type Model struct {
 
 // Workspace represents the working directory context for the session.
 type Workspace struct {
-	CurrentDir string `json:"current_dir"`
-	ProjectDir string `json:"project_dir"`
+	CurrentDir  string    `json:"current_dir"`
+	ProjectDir  string    `json:"project_dir"`
+	AddedDirs   []string  `json:"added_dirs"`
+	GitWorktree string    `json:"git_worktree"`
+	Repo        *RepoInfo `json:"repo"`
+}
+
+// RepoInfo identifies the git repository hosting the workspace, when an origin
+// remote is present.
+type RepoInfo struct {
+	Host  string `json:"host"`
+	Owner string `json:"owner"`
+	Name  string `json:"name"`
 }
 
 // Cost represents the cumulative session cost and duration metrics.
@@ -71,6 +89,47 @@ type Vim struct {
 // Agent represents the active agent teammate if in team mode.
 type Agent struct {
 	Name string `json:"name"`
+}
+
+// Effort represents the reasoning effort level, present when the model supports
+// the reasoning effort parameter.
+type Effort struct {
+	Level string `json:"level"` // e.g. "high"
+}
+
+// Thinking represents whether extended thinking is enabled.
+type Thinking struct {
+	Enabled bool `json:"enabled"`
+}
+
+// PullRequest represents an open pull request associated with the branch.
+type PullRequest struct {
+	Number      int    `json:"number"`
+	URL         string `json:"url"`
+	ReviewState string `json:"review_state"` // e.g. "pending"; may be absent
+}
+
+// Worktree represents an active --worktree session.
+type Worktree struct {
+	Name           string `json:"name"`
+	Path           string `json:"path"`
+	Branch         string `json:"branch"` // may be absent for hook-based worktrees
+	OriginalCWD    string `json:"original_cwd"`
+	OriginalBranch string `json:"original_branch"` // may be absent
+}
+
+// RateLimits holds Claude.ai subscription rate-limit usage. Present only for
+// subscribers, after the first API response. Each window can be independently absent.
+type RateLimits struct {
+	FiveHour *RateLimitWindow `json:"five_hour"`
+	SevenDay *RateLimitWindow `json:"seven_day"`
+}
+
+// RateLimitWindow is a single rate-limit window. UsedPercentage is 0-100;
+// ResetsAt is Unix epoch seconds.
+type RateLimitWindow struct {
+	UsedPercentage float64 `json:"used_percentage"`
+	ResetsAt       int64   `json:"resets_at"`
 }
 
 // RenderContext bundles all inputs for Render. Optional sources (Git, Usage,

--- a/internal/types_test.go
+++ b/internal/types_test.go
@@ -1,6 +1,134 @@
 package internal
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
+
+// fullSchemaJSON mirrors the documented Claude Code 2.1 statusline schema
+// (https://code.claude.com/docs/en/statusline) with every optional field present.
+const fullSchemaJSON = `{
+  "cwd": "/work/proj",
+  "session_id": "abc123",
+  "session_name": "my-session",
+  "transcript_path": "/t.jsonl",
+  "model": {"id": "claude-opus-4-8", "display_name": "Opus"},
+  "workspace": {
+    "current_dir": "/work/proj",
+    "project_dir": "/work/proj",
+    "added_dirs": ["/work/extra"],
+    "git_worktree": "feature-xyz",
+    "repo": {"host": "github.com", "owner": "ai-screams", "name": "howl"}
+  },
+  "version": "2.1.177",
+  "output_style": {"name": "default"},
+  "cost": {"total_cost_usd": 0.01, "total_duration_ms": 45000, "total_api_duration_ms": 2300, "total_lines_added": 5, "total_lines_removed": 1},
+  "context_window": {"total_input_tokens": 15500, "total_output_tokens": 1200, "context_window_size": 200000, "used_percentage": 8, "remaining_percentage": 92, "current_usage": {"input_tokens": 8500, "output_tokens": 1200, "cache_creation_input_tokens": 5000, "cache_read_input_tokens": 2000}},
+  "exceeds_200k_tokens": false,
+  "effort": {"level": "high"},
+  "thinking": {"enabled": true},
+  "rate_limits": {"five_hour": {"used_percentage": 23.5, "resets_at": 1738425600}, "seven_day": {"used_percentage": 41.2, "resets_at": 1738857600}},
+  "vim": {"mode": "NORMAL"},
+  "agent": {"name": "security-reviewer"},
+  "pr": {"number": 1234, "url": "https://github.com/ai-screams/howl/pull/1234", "review_state": "pending"},
+  "worktree": {"name": "my-feature", "path": "/wt/my-feature", "branch": "worktree-my-feature", "original_cwd": "/work/proj", "original_branch": "main"}
+}`
+
+func TestStdinDataFullSchemaDecode(t *testing.T) {
+	t.Parallel()
+
+	var d StdinData
+	if err := json.Unmarshal([]byte(fullSchemaJSON), &d); err != nil {
+		t.Fatalf("decode full schema: %v", err)
+	}
+
+	if d.SessionName != "my-session" {
+		t.Errorf("SessionName = %q, want my-session", d.SessionName)
+	}
+	if d.Workspace.GitWorktree != "feature-xyz" {
+		t.Errorf("Workspace.GitWorktree = %q, want feature-xyz", d.Workspace.GitWorktree)
+	}
+	if len(d.Workspace.AddedDirs) != 1 || d.Workspace.AddedDirs[0] != "/work/extra" {
+		t.Errorf("Workspace.AddedDirs = %v, want [/work/extra]", d.Workspace.AddedDirs)
+	}
+	if d.Workspace.Repo == nil || d.Workspace.Repo.Name != "howl" {
+		t.Errorf("Workspace.Repo = %+v, want name=howl", d.Workspace.Repo)
+	}
+	if d.Effort == nil || d.Effort.Level != "high" {
+		t.Errorf("Effort = %+v, want level=high", d.Effort)
+	}
+	if d.Thinking == nil || !d.Thinking.Enabled {
+		t.Errorf("Thinking = %+v, want enabled=true", d.Thinking)
+	}
+	if d.RateLimits == nil || d.RateLimits.FiveHour == nil || d.RateLimits.FiveHour.UsedPercentage != 23.5 {
+		t.Errorf("RateLimits.FiveHour = %+v, want used=23.5", d.RateLimits)
+	}
+	if d.RateLimits.FiveHour.ResetsAt != 1738425600 {
+		t.Errorf("RateLimits.FiveHour.ResetsAt = %d, want 1738425600", d.RateLimits.FiveHour.ResetsAt)
+	}
+	if d.PR == nil || d.PR.Number != 1234 || d.PR.ReviewState != "pending" {
+		t.Errorf("PR = %+v, want number=1234 review_state=pending", d.PR)
+	}
+	if d.Worktree == nil || d.Worktree.Name != "my-feature" || d.Worktree.OriginalBranch != "main" {
+		t.Errorf("Worktree = %+v, want name=my-feature original_branch=main", d.Worktree)
+	}
+}
+
+// TestStdinDataOptionalAbsence asserts that missing top-level objects and missing
+// subfields decode safely (nil pointers / zero strings), so renderers can omit them.
+func TestStdinDataOptionalAbsence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("minimal payload leaves optionals nil", func(t *testing.T) {
+		t.Parallel()
+		var d StdinData
+		if err := json.Unmarshal([]byte(`{"session_id":"x","model":{"display_name":"Opus"}}`), &d); err != nil {
+			t.Fatalf("decode minimal: %v", err)
+		}
+		for name, isNil := range map[string]bool{
+			"Effort":     d.Effort == nil,
+			"Thinking":   d.Thinking == nil,
+			"RateLimits": d.RateLimits == nil,
+			"PR":         d.PR == nil,
+			"Worktree":   d.Worktree == nil,
+			"Repo":       d.Workspace.Repo == nil,
+		} {
+			if !isNil {
+				t.Errorf("%s should be nil when absent", name)
+			}
+		}
+	})
+
+	t.Run("present objects with absent subfields", func(t *testing.T) {
+		t.Parallel()
+		var d StdinData
+		// pr without review_state; worktree without branch/original_branch
+		js := `{"pr":{"number":7},"worktree":{"name":"wt","path":"/p"}}`
+		if err := json.Unmarshal([]byte(js), &d); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if d.PR == nil || d.PR.Number != 7 || d.PR.ReviewState != "" {
+			t.Errorf("PR = %+v, want number=7 review_state empty", d.PR)
+		}
+		if d.Worktree == nil || d.Worktree.Branch != "" || d.Worktree.OriginalBranch != "" {
+			t.Errorf("Worktree = %+v, want empty branch fields", d.Worktree)
+		}
+	})
+
+	t.Run("rate_limits with only one window", func(t *testing.T) {
+		t.Parallel()
+		var d StdinData
+		if err := json.Unmarshal([]byte(`{"rate_limits":{"five_hour":{"used_percentage":10,"resets_at":1}}}`), &d); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if d.RateLimits == nil || d.RateLimits.FiveHour == nil {
+			t.Fatalf("expected five_hour window, got %+v", d.RateLimits)
+		}
+		if d.RateLimits.SevenDay != nil {
+			t.Errorf("SevenDay = %+v, want nil when absent", d.RateLimits.SevenDay)
+		}
+	})
+}
 
 func TestClassifyModel(t *testing.T) {
 	t.Parallel()

--- a/internal/usage.go
+++ b/internal/usage.go
@@ -1,183 +1,45 @@
 package internal
 
-import (
-	"context"
-	"encoding/json"
-	"io"
-	"net/http"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
-	"time"
-)
+import "time"
 
-// UsageData represents the OAuth API usage quota with 5-hour and 7-day limits.
+// UsageWindow is the render model for a single rate-limit window. Presence is
+// signalled by a non-nil pointer — zero is a valid quota state, never "absent".
+type UsageWindow struct {
+	RemainingPercent float64
+	ResetsAt         time.Time
+}
+
+// UsageData holds quota for display. Each window is independently optional,
+// matching the Claude Code `rate_limits` contract.
 type UsageData struct {
-	RemainingPercent5h float64   `json:"remaining_percent_5h"`
-	RemainingPercent7d float64   `json:"remaining_percent_7d"`
-	ResetsAt5h         time.Time `json:"resets_at_5h"`
-	ResetsAt7d         time.Time `json:"resets_at_7d"`
-	FetchedAt          int64     `json:"fetched_at"`
+	FiveHour *UsageWindow
+	SevenDay *UsageWindow
 }
 
-type usageAPIResponse struct {
-	FiveHour struct {
-		Utilization float64 `json:"utilization"`
-		ResetsAt    string  `json:"resets_at"`
-	} `json:"five_hour"`
-	SevenDay struct {
-		Utilization float64 `json:"utilization"`
-		ResetsAt    string  `json:"resets_at"`
-	} `json:"seven_day"`
-}
-
-// usageAPIURL is the OAuth usage API endpoint. Package-level var for test substitution.
-var usageAPIURL = "https://api.anthropic.com/api/oauth/usage"
-
-// getOAuthTokenFunc returns the OAuth token. Package-level var for test substitution.
-var getOAuthTokenFunc = getOAuthToken
-
-const (
-	cacheTTL   = UsageCacheTTL
-	apiTimeout = UsageAPITimeout
-)
-
-// GetUsage fetches OAuth usage data with session-scoped caching.
-// Returns nil on any failure — usage quota is optional.
-func GetUsage(sessionID string) *UsageData {
-	if sessionID == "" {
+// UsageFromRateLimits converts the stdin `rate_limits` object into the render
+// model. Pure function — no network, cache, or Keychain. Returns nil when no
+// quota data is available so the renderer omits the section.
+func UsageFromRateLimits(rl *RateLimits) *UsageData {
+	if rl == nil {
 		return nil
 	}
-
-	// Try cache first
-	if cached := loadCachedUsage(sessionID); cached != nil {
-		if time.Since(time.Unix(cached.FetchedAt, 0)) < cacheTTL {
-			return cached
-		}
-	}
-
-	// Fetch fresh data
-	token := getOAuthTokenFunc()
-	if token == "" {
-		return nil
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, "GET", usageAPIURL, nil)
-	if err != nil {
-		return nil
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("anthropic-beta", "oauth-2025-04-20")
-	req.Header.Set("User-Agent", "howl/1.0")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != 200 {
-		return nil
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB max
-	if err != nil {
-		return nil
-	}
-
-	var apiResp usageAPIResponse
-	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return nil
-	}
-
-	// Parse reset times
-	resetTime5h, _ := time.Parse(time.RFC3339, apiResp.FiveHour.ResetsAt)
-	resetTime7d, _ := time.Parse(time.RFC3339, apiResp.SevenDay.ResetsAt)
-
-	// Convert utilization to remaining percentage
-	// API returns utilization (used %), we want remaining %
 	usage := &UsageData{
-		RemainingPercent5h: 100 - apiResp.FiveHour.Utilization,
-		RemainingPercent7d: 100 - apiResp.SevenDay.Utilization,
-		ResetsAt5h:         resetTime5h,
-		ResetsAt7d:         resetTime7d,
-		FetchedAt:          time.Now().Unix(),
+		FiveHour: usageWindowFromRateLimit(rl.FiveHour),
+		SevenDay: usageWindowFromRateLimit(rl.SevenDay),
 	}
-
-	// Cache it
-	saveCachedUsage(sessionID, usage)
+	if usage.FiveHour == nil && usage.SevenDay == nil {
+		return nil
+	}
 	return usage
 }
 
-func getOAuthToken() string {
-	ctx, cancel := context.WithTimeout(context.Background(), apiTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "/usr/bin/security", "find-generic-password",
-		"-s", "Claude Code-credentials",
-		"-w")
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-
-	// Extract accessToken via regex. The Keychain stores all Claude Code
-	// credentials in one large JSON blob that may exceed the ~2KB output
-	// limit of `security -w`, producing truncated (unparseable) JSON.
-	// Regex extraction is robust against truncation since the token appears
-	// near the start of the blob.
-	return extractAccessToken(out)
-}
-
-func sanitizeSessionID(sessionID string) string {
-	return filepath.Base(sessionID)
-}
-
-func cacheDir(sessionID string) string {
-	return filepath.Join(os.TempDir(), "howl-"+sanitizeSessionID(sessionID))
-}
-
-func cachePath(sessionID string) string {
-	return filepath.Join(cacheDir(sessionID), "usage.json")
-}
-
-func loadCachedUsage(sessionID string) *UsageData {
-	path := cachePath(sessionID)
-	data, err := os.ReadFile(path)
-	if err != nil {
+func usageWindowFromRateLimit(w *RateLimitWindow) *UsageWindow {
+	if w == nil {
 		return nil
 	}
-	var usage UsageData
-	if err := json.Unmarshal(data, &usage); err != nil {
-		return nil
+	used := min(max(w.UsedPercentage, 0), 100) // contract is 0-100; clamp defensively
+	return &UsageWindow{
+		RemainingPercent: 100 - used,
+		ResetsAt:         time.Unix(w.ResetsAt, 0),
 	}
-	return &usage
-}
-
-func saveCachedUsage(sessionID string, usage *UsageData) {
-	dir := cacheDir(sessionID)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return
-	}
-	data, err := json.Marshal(usage)
-	if err != nil {
-		return
-	}
-	_ = os.WriteFile(cachePath(sessionID), data, 0600)
-}
-
-// accessTokenRe matches "accessToken":"<value>" in JSON, tolerating truncated blobs.
-var accessTokenRe = regexp.MustCompile(`"accessToken"\s*:\s*"([^"]+)"`)
-
-// extractAccessToken pulls the OAuth access token from a potentially truncated
-// Keychain JSON blob using regex instead of json.Unmarshal.
-func extractAccessToken(data []byte) string {
-	m := accessTokenRe.FindSubmatch(data)
-	if m == nil {
-		return ""
-	}
-	return string(m[1])
 }

--- a/internal/usage_test.go
+++ b/internal/usage_test.go
@@ -1,43 +1,9 @@
 package internal
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"strings"
 	"testing"
 	"time"
 )
-
-func TestSanitizeSessionID(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{"normal id", "abc-123-def", "abc-123-def"},
-		{"path traversal", "../../../etc/passwd", "passwd"},
-		{"absolute path", "/absolute/path/id", "id"},
-		{"dot", ".", "."},
-		{"double dot", "..", ".."},
-		{"empty", "", "."},
-		{"nested traversal", "foo/../bar", "bar"},
-		{"just slash", "/", "/"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := sanitizeSessionID(tt.input)
-			if got != tt.want {
-				t.Errorf("sanitizeSessionID(%q) = %q, want %q", tt.input, got, tt.want)
-			}
-		})
-	}
-}
 
 func TestQuotaColor(t *testing.T) {
 	t.Parallel()
@@ -85,66 +51,16 @@ func TestFormatTimeUntil(t *testing.T) {
 		target time.Time
 		want   string
 	}{
-		{
-			name:   "zero target",
-			now:    baseTime,
-			target: time.Time{},
-			want:   "?",
-		},
-		{
-			name:   "expired past",
-			now:    baseTime,
-			target: baseTime.Add(-1 * time.Hour),
-			want:   "0d00h",
-		},
-		{
-			name:   "expired exact",
-			now:    baseTime,
-			target: baseTime,
-			want:   "0d00h",
-		},
-		{
-			name:   "3 hours future",
-			now:    baseTime,
-			target: baseTime.Add(3 * time.Hour),
-			want:   "0d03h",
-		},
-		{
-			name:   "25 hours future",
-			now:    baseTime,
-			target: baseTime.Add(25 * time.Hour),
-			want:   "1d01h",
-		},
-		{
-			name:   "48 hours future",
-			now:    baseTime,
-			target: baseTime.Add(48 * time.Hour),
-			want:   "2d00h",
-		},
-		{
-			name:   "1 minute future",
-			now:    baseTime,
-			target: baseTime.Add(1 * time.Minute),
-			want:   "0d00h",
-		},
-		{
-			name:   "23 hours 59 minutes",
-			now:    baseTime,
-			target: baseTime.Add(23*time.Hour + 59*time.Minute),
-			want:   "0d23h",
-		},
-		{
-			name:   "7 days exact",
-			now:    baseTime,
-			target: baseTime.Add(7 * 24 * time.Hour),
-			want:   "7d00h",
-		},
-		{
-			name:   "3 days 12 hours",
-			now:    baseTime,
-			target: baseTime.Add(3*24*time.Hour + 12*time.Hour),
-			want:   "3d12h",
-		},
+		{"zero target", baseTime, time.Time{}, "?"},
+		{"expired past", baseTime, baseTime.Add(-1 * time.Hour), "0d00h"},
+		{"expired exact", baseTime, baseTime, "0d00h"},
+		{"3 hours future", baseTime, baseTime.Add(3 * time.Hour), "0d03h"},
+		{"25 hours future", baseTime, baseTime.Add(25 * time.Hour), "1d01h"},
+		{"48 hours future", baseTime, baseTime.Add(48 * time.Hour), "2d00h"},
+		{"1 minute future", baseTime, baseTime.Add(1 * time.Minute), "0d00h"},
+		{"23 hours 59 minutes", baseTime, baseTime.Add(23*time.Hour + 59*time.Minute), "0d23h"},
+		{"7 days exact", baseTime, baseTime.Add(7 * 24 * time.Hour), "7d00h"},
+		{"3 days 12 hours", baseTime, baseTime.Add(3*24*time.Hour + 12*time.Hour), "3d12h"},
 	}
 
 	for _, tt := range tests {
@@ -158,399 +74,102 @@ func TestFormatTimeUntil(t *testing.T) {
 	}
 }
 
-// saveAndRestore saves package-level vars and restores them via t.Cleanup.
-func saveAndRestore(t *testing.T) {
-	t.Helper()
-	origURL := usageAPIURL
-	origTokenFunc := getOAuthTokenFunc
-	t.Cleanup(func() {
-		usageAPIURL = origURL
-		getOAuthTokenFunc = origTokenFunc
-	})
-}
-
-// Group 1: Cache Functions
-
-func TestCacheDir(t *testing.T) {
-	sessionID := "test-session-123"
-	got := cacheDir(sessionID)
-	if !strings.Contains(got, "howl-") {
-		t.Errorf("cacheDir(%q) = %q, expected to contain 'howl-' prefix", sessionID, got)
-	}
-	if !strings.Contains(got, "test-session-123") {
-		t.Errorf("cacheDir(%q) = %q, expected to contain session ID", sessionID, got)
-	}
-}
-
-func TestCachePath(t *testing.T) {
-	sessionID := "test-session-456"
-	got := cachePath(sessionID)
-	if !strings.HasSuffix(got, "usage.json") {
-		t.Errorf("cachePath(%q) = %q, expected to end with 'usage.json'", sessionID, got)
-	}
-	if !strings.Contains(got, "howl-") {
-		t.Errorf("cachePath(%q) = %q, expected to contain 'howl-' prefix", sessionID, got)
-	}
-}
-
-func TestLoadCachedUsage_NoFile(t *testing.T) {
-	sessionID := "nonexistent-session-" + t.Name()
-	got := loadCachedUsage(sessionID)
-	if got != nil {
-		t.Errorf("loadCachedUsage(%q) = %+v, want nil for nonexistent file", sessionID, got)
-	}
-}
-
-func TestLoadCachedUsage_BadJSON(t *testing.T) {
-	sessionID := "bad-json-session-" + t.Name()
-	dir := cacheDir(sessionID)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		t.Fatalf("Failed to create cache dir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-
-	path := cachePath(sessionID)
-	if err := os.WriteFile(path, []byte("not valid json {{{"), 0600); err != nil {
-		t.Fatalf("Failed to write bad JSON: %v", err)
-	}
-
-	got := loadCachedUsage(sessionID)
-	if got != nil {
-		t.Errorf("loadCachedUsage(%q) = %+v, want nil for invalid JSON", sessionID, got)
-	}
-}
-
-func TestCacheRoundTrip(t *testing.T) {
-	sessionID := "roundtrip-session-" + t.Name()
-	dir := cacheDir(sessionID)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-
-	baseTime := time.Date(2026, 2, 10, 10, 30, 0, 0, time.UTC)
-	original := &UsageData{
-		RemainingPercent5h: 42.5,
-		RemainingPercent7d: 67.8,
-		ResetsAt5h:         baseTime.Add(2 * time.Hour),
-		ResetsAt7d:         baseTime.Add(4 * 24 * time.Hour),
-		FetchedAt:          baseTime.Unix(),
-	}
-
-	saveCachedUsage(sessionID, original)
-	loaded := loadCachedUsage(sessionID)
-
-	if loaded == nil {
-		t.Fatal("loadCachedUsage() returned nil after save")
-	}
-
-	if loaded.RemainingPercent5h != original.RemainingPercent5h {
-		t.Errorf("RemainingPercent5h mismatch: got %v, want %v", loaded.RemainingPercent5h, original.RemainingPercent5h)
-	}
-	if loaded.RemainingPercent7d != original.RemainingPercent7d {
-		t.Errorf("RemainingPercent7d mismatch: got %v, want %v", loaded.RemainingPercent7d, original.RemainingPercent7d)
-	}
-	if !loaded.ResetsAt5h.Equal(original.ResetsAt5h) {
-		t.Errorf("ResetsAt5h mismatch: got %v, want %v", loaded.ResetsAt5h, original.ResetsAt5h)
-	}
-	if !loaded.ResetsAt7d.Equal(original.ResetsAt7d) {
-		t.Errorf("ResetsAt7d mismatch: got %v, want %v", loaded.ResetsAt7d, original.ResetsAt7d)
-	}
-	if loaded.FetchedAt != original.FetchedAt {
-		t.Errorf("FetchedAt mismatch: got %v, want %v", loaded.FetchedAt, original.FetchedAt)
-	}
-}
-
-// Group 2: GetUsage Edge Cases
-
-func TestGetUsage_EmptySession(t *testing.T) {
-	got := GetUsage("")
-	if got != nil {
-		t.Errorf("GetUsage(\"\") = %+v, want nil for empty session", got)
-	}
-}
-
-func TestGetUsage_CacheHit(t *testing.T) {
-	sessionID := "cache-hit-session-" + t.Name()
-	dir := cacheDir(sessionID)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-
-	// Pre-populate fresh cache
-	baseTime := time.Now()
-	cached := &UsageData{
-		RemainingPercent5h: 55.0,
-		RemainingPercent7d: 75.0,
-		ResetsAt5h:         baseTime.Add(1 * time.Hour),
-		ResetsAt7d:         baseTime.Add(3 * 24 * time.Hour),
-		FetchedAt:          baseTime.Unix(), // fresh cache
-	}
-	saveCachedUsage(sessionID, cached)
-
-	// Should return cached data without HTTP
-	got := GetUsage(sessionID)
-	if got == nil {
-		t.Fatal("GetUsage() returned nil, expected cached data")
-	}
-
-	if got.RemainingPercent5h != 55.0 {
-		t.Errorf("GetUsage() RemainingPercent5h = %v, want 55.0 from cache", got.RemainingPercent5h)
-	}
-	if got.RemainingPercent7d != 75.0 {
-		t.Errorf("GetUsage() RemainingPercent7d = %v, want 75.0 from cache", got.RemainingPercent7d)
-	}
-}
-
-func TestGetUsage_CacheExpired(t *testing.T) {
-	saveAndRestore(t)
-
-	sessionID := "cache-expired-session-" + t.Name()
-	dir := cacheDir(sessionID)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-
-	// Pre-populate expired cache (61 seconds ago, TTL is 60s)
-	expiredTime := time.Now().Add(-61 * time.Second)
-	expired := &UsageData{
-		RemainingPercent5h: 55.0,
-		RemainingPercent7d: 75.0,
-		ResetsAt5h:         time.Now().Add(1 * time.Hour),
-		ResetsAt7d:         time.Now().Add(3 * 24 * time.Hour),
-		FetchedAt:          expiredTime.Unix(),
-	}
-	saveCachedUsage(sessionID, expired)
-
-	// Mock token func to return empty (no OAuth token available)
-	getOAuthTokenFunc = func() string { return "" }
-
-	got := GetUsage(sessionID)
-	if got != nil {
-		t.Errorf("GetUsage() = %+v, want nil when cache expired and no token", got)
-	}
-}
-
-// Group 3: HTTP Path
-
-func TestGetUsage_HTTPSuccess(t *testing.T) {
-	saveAndRestore(t)
-
-	sessionID := "http-success-session-" + t.Name()
-	dir := cacheDir(sessionID)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-
-	// Mock server
-	var receivedAuthHeader string
-	var receivedBetaHeader string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedAuthHeader = r.Header.Get("Authorization")
-		receivedBetaHeader = r.Header.Get("anthropic-beta")
-
-		response := usageAPIResponse{
-			FiveHour: struct {
-				Utilization float64 `json:"utilization"`
-				ResetsAt    string  `json:"resets_at"`
-			}{
-				Utilization: 30.0, // API returns used percentage
-				ResetsAt:    "2026-02-10T15:00:00Z",
-			},
-			SevenDay: struct {
-				Utilization float64 `json:"utilization"`
-				ResetsAt    string  `json:"resets_at"`
-			}{
-				Utilization: 20.0,
-				ResetsAt:    "2026-02-15T12:00:00Z",
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(response); err != nil {
-			t.Errorf("Failed to encode response: %v", err)
-		}
-	}))
-	defer server.Close()
-
-	usageAPIURL = server.URL
-	getOAuthTokenFunc = func() string { return "test-token" }
-
-	got := GetUsage(sessionID)
-
-	// Verify request headers
-	if receivedAuthHeader != "Bearer test-token" {
-		t.Errorf("Authorization header = %q, want %q", receivedAuthHeader, "Bearer test-token")
-	}
-	if receivedBetaHeader != "oauth-2025-04-20" {
-		t.Errorf("anthropic-beta header = %q, want %q", receivedBetaHeader, "oauth-2025-04-20")
-	}
-
-	// Verify utilization→remaining conversion
-	if got == nil {
-		t.Fatal("GetUsage() returned nil, expected valid data")
-	}
-	if got.RemainingPercent5h != 70.0 { // 100 - 30
-		t.Errorf("RemainingPercent5h = %v, want 70.0 (100 - 30)", got.RemainingPercent5h)
-	}
-	if got.RemainingPercent7d != 80.0 { // 100 - 20
-		t.Errorf("RemainingPercent7d = %v, want 80.0 (100 - 20)", got.RemainingPercent7d)
-	}
-
-	// Verify caching
-	cached := loadCachedUsage(sessionID)
-	if cached == nil {
-		t.Error("Result was not cached after fetch")
-	} else if cached.RemainingPercent5h != 70.0 {
-		t.Errorf("Cached RemainingPercent5h = %v, want 70.0", cached.RemainingPercent5h)
-	}
-}
-
-func TestGetUsage_NoToken(t *testing.T) {
-	saveAndRestore(t)
-
-	sessionID := "no-token-session-" + t.Name()
-	getOAuthTokenFunc = func() string { return "" }
-
-	got := GetUsage(sessionID)
-	if got != nil {
-		t.Errorf("GetUsage() = %+v, want nil when no token available", got)
-	}
-}
-
-func TestGetUsage_HTTPError(t *testing.T) {
-	saveAndRestore(t)
-
-	sessionID := "http-error-session-" + t.Name()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
-
-	usageAPIURL = server.URL
-	getOAuthTokenFunc = func() string { return "test-token" }
-
-	got := GetUsage(sessionID)
-	if got != nil {
-		t.Errorf("GetUsage() = %+v, want nil on HTTP 500", got)
-	}
-}
-
-func TestGetUsage_BadResponseJSON(t *testing.T) {
-	saveAndRestore(t)
-
-	sessionID := "bad-response-json-session-" + t.Name()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte("invalid json {{{"))
-	}))
-	defer server.Close()
-
-	usageAPIURL = server.URL
-	getOAuthTokenFunc = func() string { return "test-token" }
-
-	got := GetUsage(sessionID)
-	if got != nil {
-		t.Errorf("GetUsage() = %+v, want nil on invalid JSON response", got)
-	}
-}
-
-func TestGetUsage_HTTP403(t *testing.T) {
-	saveAndRestore(t)
-
-	sessionID := "http-403-session-" + t.Name()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-	}))
-	defer server.Close()
-
-	usageAPIURL = server.URL
-	getOAuthTokenFunc = func() string { return "test-token" }
-
-	got := GetUsage(sessionID)
-	if got != nil {
-		t.Errorf("GetUsage() = %+v, want nil on HTTP 403", got)
-	}
-}
-
-func TestGetUsage_PartialAPIResponse(t *testing.T) {
-	saveAndRestore(t)
-
-	sessionID := "partial-response-session-" + t.Name()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Missing resets_at fields
-		response := map[string]interface{}{
-			"five_hour": map[string]interface{}{
-				"utilization": 25.0,
-			},
-			"seven_day": map[string]interface{}{
-				"utilization": 15.0,
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(response); err != nil {
-			t.Errorf("Failed to encode response: %v", err)
-		}
-	}))
-	defer server.Close()
-
-	usageAPIURL = server.URL
-	getOAuthTokenFunc = func() string { return "test-token" }
-
-	got := GetUsage(sessionID)
-	if got == nil {
-		t.Fatal("GetUsage() returned nil, expected partial data")
-	}
-
-	// Verify utilization conversion works
-	if got.RemainingPercent5h != 75.0 { // 100 - 25
-		t.Errorf("RemainingPercent5h = %v, want 75.0", got.RemainingPercent5h)
-	}
-
-	// Verify zero times for missing resets_at
-	if !got.ResetsAt5h.IsZero() {
-		t.Errorf("ResetsAt5h = %v, want zero time for missing field", got.ResetsAt5h)
-	}
-	if !got.ResetsAt7d.IsZero() {
-		t.Errorf("ResetsAt7d = %v, want zero time for missing field", got.ResetsAt7d)
-	}
-}
-
-func TestExtractAccessToken(t *testing.T) {
+func TestUsageFromRateLimits(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{
-			name:  "valid complete JSON",
-			input: `{"claudeAiOauth":{"accessToken":"sk-ant-token123"}}`,
-			want:  "sk-ant-token123",
-		},
-		{
-			name:  "truncated JSON (Keychain ~2KB limit)",
-			input: `{"claudeAiOauth":{"accessToken":"sk-ant-token456"},"other":{"nested":{"deep":"val`,
-			want:  "sk-ant-token456",
-		},
-		{
-			name:  "JSON with control characters before token",
-			input: "{\"claudeAiOauth\":{\"accessToken\":\"sk-ant-token789\"},\"x\":\"line1\nline2\"}",
-			want:  "sk-ant-token789",
-		},
-		{
-			name:  "empty input",
-			input: "",
-			want:  "",
-		},
-		{
-			name:  "no accessToken field",
-			input: `{"claudeAiOauth":{"refreshToken":"rt-123"}}`,
-			want:  "",
-		},
-		{
-			name:  "whitespace around colon",
-			input: `{"claudeAiOauth":{"accessToken" : "sk-ant-spaced"}}`,
-			want:  "sk-ant-spaced",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := extractAccessToken([]byte(tt.input))
-			if got != tt.want {
-				t.Errorf("extractAccessToken() = %q, want %q", got, tt.want)
-			}
+
+	t.Run("nil rate_limits returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := UsageFromRateLimits(nil); got != nil {
+			t.Errorf("UsageFromRateLimits(nil) = %+v, want nil", got)
+		}
+	})
+
+	t.Run("both windows absent returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := UsageFromRateLimits(&RateLimits{}); got != nil {
+			t.Errorf("UsageFromRateLimits(empty) = %+v, want nil", got)
+		}
+	})
+
+	t.Run("both windows present", func(t *testing.T) {
+		t.Parallel()
+		got := UsageFromRateLimits(&RateLimits{
+			FiveHour: &RateLimitWindow{UsedPercentage: 23.5, ResetsAt: 1738425600},
+			SevenDay: &RateLimitWindow{UsedPercentage: 41.2, ResetsAt: 1738857600},
 		})
-	}
+		if got == nil {
+			t.Fatal("UsageFromRateLimits() = nil, want non-nil")
+		}
+		if got.FiveHour == nil || got.SevenDay == nil {
+			t.Fatalf("expected both windows present, got %+v", got)
+		}
+		if got.FiveHour.RemainingPercent != 76.5 {
+			t.Errorf("FiveHour.RemainingPercent = %v, want 76.5", got.FiveHour.RemainingPercent)
+		}
+		if got.SevenDay.RemainingPercent != 58.8 {
+			t.Errorf("SevenDay.RemainingPercent = %v, want 58.8", got.SevenDay.RemainingPercent)
+		}
+		if !got.FiveHour.ResetsAt.Equal(time.Unix(1738425600, 0)) {
+			t.Errorf("FiveHour.ResetsAt = %v, want %v", got.FiveHour.ResetsAt, time.Unix(1738425600, 0))
+		}
+		if !got.SevenDay.ResetsAt.Equal(time.Unix(1738857600, 0)) {
+			t.Errorf("SevenDay.ResetsAt = %v, want %v", got.SevenDay.ResetsAt, time.Unix(1738857600, 0))
+		}
+	})
+
+	t.Run("only 5h present", func(t *testing.T) {
+		t.Parallel()
+		got := UsageFromRateLimits(&RateLimits{
+			FiveHour: &RateLimitWindow{UsedPercentage: 10, ResetsAt: 1738425600},
+		})
+		if got == nil || got.FiveHour == nil {
+			t.Fatalf("expected 5h window, got %+v", got)
+		}
+		if got.SevenDay != nil {
+			t.Errorf("SevenDay = %+v, want nil (absent window must not be fabricated)", got.SevenDay)
+		}
+	})
+
+	t.Run("only 7d present", func(t *testing.T) {
+		t.Parallel()
+		got := UsageFromRateLimits(&RateLimits{
+			SevenDay: &RateLimitWindow{UsedPercentage: 90, ResetsAt: 1738857600},
+		})
+		if got == nil || got.SevenDay == nil {
+			t.Fatalf("expected 7d window, got %+v", got)
+		}
+		if got.FiveHour != nil {
+			t.Errorf("FiveHour = %+v, want nil", got.FiveHour)
+		}
+	})
+
+	t.Run("clamps out-of-range percentages", func(t *testing.T) {
+		t.Parallel()
+		got := UsageFromRateLimits(&RateLimits{
+			FiveHour: &RateLimitWindow{UsedPercentage: 150}, // -> remaining 0
+			SevenDay: &RateLimitWindow{UsedPercentage: -20}, // -> remaining 100
+		})
+		if got == nil || got.FiveHour == nil || got.SevenDay == nil {
+			t.Fatalf("expected both windows, got %+v", got)
+		}
+		if got.FiveHour.RemainingPercent != 0 {
+			t.Errorf("FiveHour.RemainingPercent = %v, want 0 (clamped from used 150)", got.FiveHour.RemainingPercent)
+		}
+		if got.SevenDay.RemainingPercent != 100 {
+			t.Errorf("SevenDay.RemainingPercent = %v, want 100 (clamped from used -20)", got.SevenDay.RemainingPercent)
+		}
+	})
+
+	t.Run("zero used is a valid 100% remaining window, not absent", func(t *testing.T) {
+		t.Parallel()
+		got := UsageFromRateLimits(&RateLimits{
+			FiveHour: &RateLimitWindow{UsedPercentage: 0, ResetsAt: 1738425600},
+		})
+		if got == nil || got.FiveHour == nil {
+			t.Fatalf("expected 5h window present, got %+v", got)
+		}
+		if got.FiveHour.RemainingPercent != 100 {
+			t.Errorf("RemainingPercent = %v, want 100", got.FiveHour.RemainingPercent)
+		}
+	})
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,50 +95,73 @@ mv "$TMPDIR_DL/$ASSET_NAME" "$INSTALL_DIR/$BINARY"
 chmod +x "$INSTALL_DIR/$BINARY"
 echo "  Binary installed: $INSTALL_DIR/$BINARY"
 
-# Configure statusline in settings.json
+# Configure statusline in settings.json.
+# Modern statusLine block (Claude Code 2.1):
+#   - refreshInterval: re-run when idle (time-based metrics, quota countdowns)
+#   - hideVimModeIndicator: Howl renders vim.mode itself, so suppress the native one
 configure_settings() {
   local cmd="$INSTALL_DIR/$BINARY"
 
+  # No settings file -> create the full modern block.
   if [ ! -f "$SETTINGS" ]; then
     mkdir -p "$(dirname "$SETTINGS")"
-    printf '{\n  "statusLine": {\n    "type": "command",\n    "command": "%s"\n  }\n}\n' "$cmd" > "$SETTINGS"
+    printf '{\n  "statusLine": {\n    "type": "command",\n    "command": "%s",\n    "refreshInterval": 10,\n    "hideVimModeIndicator": true\n  }\n}\n' "$cmd" > "$SETTINGS"
     echo "  Created $SETTINGS"
     return
   fi
 
-  # Check if statusLine already configured
-  if grep -q '"statusLine"' "$SETTINGS" 2>/dev/null; then
-    echo "  statusLine already configured in $SETTINGS"
-    echo "  Verify it points to: $cmd"
+  # Existing settings: a JSON tool is required to patch safely.
+  if command -v jq &>/dev/null; then
+    local existing
+    existing=$(jq -r '.statusLine.command // empty' "$SETTINGS" 2>/dev/null)
+    if [ -n "$existing" ] && ! printf '%s' "$existing" | grep -q 'howl'; then
+      echo "  Existing non-Howl statusLine detected: $existing"
+      echo "  Leaving it untouched. To use Howl, set statusLine.command to: $cmd"
+      return
+    fi
+    cp "$SETTINGS" "$SETTINGS.bak"
+    # Set/repoint to Howl and add modern fields, preserving any user-set values.
+    jq --arg cmd "$cmd" '.statusLine = {
+        "type": "command",
+        "command": $cmd,
+        "refreshInterval": (.statusLine.refreshInterval // 10),
+        "hideVimModeIndicator": (.statusLine.hideVimModeIndicator // true)
+      }' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
+    echo "  Statusline configured in $SETTINGS"
     return
   fi
 
-  # Backup before modifying
-  cp "$SETTINGS" "$SETTINGS.bak"
-
-  # Append statusLine to existing settings using available JSON tool
-  if command -v jq &>/dev/null; then
-    jq --arg cmd "$cmd" '.statusLine = {"type": "command", "command": $cmd}' \
-      "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
-  elif command -v python3 &>/dev/null; then
+  if command -v python3 &>/dev/null; then
+    cp "$SETTINGS" "$SETTINGS.bak"
     HOWL_SETTINGS_PATH="$SETTINGS" HOWL_BINARY_PATH="$cmd" python3 -c "
-import json, os
-settings_path = os.environ['HOWL_SETTINGS_PATH']
-binary_path = os.environ['HOWL_BINARY_PATH']
-with open(settings_path) as f:
+import json, os, sys
+path = os.environ['HOWL_SETTINGS_PATH']
+cmd = os.environ['HOWL_BINARY_PATH']
+with open(path) as f:
     d = json.load(f)
-d['statusLine'] = {'type': 'command', 'command': binary_path}
-with open(settings_path, 'w') as f:
+sl = d.get('statusLine') or {}
+existing = sl.get('command', '')
+if existing and 'howl' not in existing:
+    print('  Existing non-Howl statusLine detected: ' + existing)
+    print('  Leaving it untouched. To use Howl, set statusLine.command to: ' + cmd)
+    sys.exit(0)
+d['statusLine'] = {
+    'type': 'command',
+    'command': cmd,
+    'refreshInterval': sl.get('refreshInterval', 10),
+    'hideVimModeIndicator': sl.get('hideVimModeIndicator', True),
+}
+with open(path, 'w') as f:
     json.dump(d, f, indent=2)
     f.write('\n')
+print('  Statusline configured in ' + path)
 "
-  else
-    echo "  Warning: Neither jq nor python3 found."
-    echo "  Add manually to $SETTINGS:"
-    echo "    \"statusLine\": {\"type\": \"command\", \"command\": \"$cmd\"}"
     return
   fi
-  echo "  Statusline configured in $SETTINGS"
+
+  echo "  Warning: Neither jq nor python3 found."
+  echo "  Add manually to $SETTINGS:"
+  echo "    \"statusLine\": {\"type\": \"command\", \"command\": \"$cmd\", \"refreshInterval\": 10, \"hideVimModeIndicator\": true}"
 }
 
 configure_settings

--- a/scripts/sync-binary.sh
+++ b/scripts/sync-binary.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# sync-binary.sh — keep the installed Howl binary in step with the plugin version.
+#
+# Runs from the plugin's SessionStart hook. Claude Code auto-updates the plugin
+# *content* (skills, scripts, plugin.json) from the marketplace, but the Howl
+# *binary* at ~/.claude/hud/howl is a separately-downloaded release artifact and
+# would otherwise drift. This script closes that gap.
+#
+# Behaviour:
+#   - Fast no-op (no network) when already in sync — the common case.
+#   - Only ever UPDATES an existing install; never auto-installs unprompted
+#     (a user with no binary is expected to run /howl:setup explicitly).
+#   - On a plugin version change, re-runs the installer in the background so
+#     session start is never blocked. Fails silently; retries next session.
+set -u
+
+root="${CLAUDE_PLUGIN_ROOT:-}"
+[ -n "$root" ] || exit 0
+
+manifest="$root/.claude-plugin/plugin.json"
+[ -f "$manifest" ] || exit 0
+
+binary="$HOME/.claude/hud/howl"
+# Only manage updates for an existing install — do not auto-install unprompted.
+[ -x "$binary" ] || exit 0
+
+# CLAUDE_PLUGIN_DATA is the persistent per-plugin state dir (survives updates).
+# Fall back to a stable location on older Claude Code that doesn't set it.
+data="${CLAUDE_PLUGIN_DATA:-$HOME/.claude/hud/.plugin-state}"
+mkdir -p "$data" 2>/dev/null || exit 0
+saved="$data/plugin.json"
+
+# In sync (binary present + recorded manifest matches current) -> nothing to do.
+[ -f "$saved" ] && cmp -s "$manifest" "$saved" && exit 0
+
+# Out of sync: fetch the matching release in the background. Record the manifest
+# only on success so a failed/offline run retries on the next session start.
+nohup env HOWL_ROOT="$root" HOWL_MANIFEST="$manifest" HOWL_SAVED="$saved" bash -c '
+  if bash "$HOWL_ROOT/scripts/install.sh" >/dev/null 2>&1; then
+    cp "$HOWL_MANIFEST" "$HOWL_SAVED" 2>/dev/null || true
+  fi
+' >/dev/null 2>&1 &
+
+exit 0

--- a/skills/configure/SKILL.md
+++ b/skills/configure/SKILL.md
@@ -9,12 +9,12 @@ Help the user choose a display preset for their Howl statusline HUD.
 
 ## Available Presets
 
-| Preset           | Lines | Best For            | Displays                                        |
-| ---------------- | ----- | ------------------- | ----------------------------------------------- |
-| **full**         | 2-4   | Complete visibility | All 13 metrics (default)                        |
-| **minimal**      | 1     | Clean workspace     | Model + Context + Cost + Duration               |
-| **developer**    | 2     | Coding focus        | + Account + Git + Changes + Speed + Cache + Vim |
-| **cost-focused** | 2     | Budget tracking     | + Quota + API Wait + Cost Velocity              |
+| Preset           | Lines | Best For            | Displays                                |
+| ---------------- | ----- | ------------------- | --------------------------------------- |
+| **full**         | 2-4   | Complete visibility | All metrics (default)                   |
+| **minimal**      | 1     | Clean workspace     | Model + Context + Cost + Duration       |
+| **developer**    | 2     | Coding focus        | + Account + Git + Changes + Cache + Vim |
+| **cost-focused** | 2     | Budget tracking     | + Quota + API Wait + Cost Velocity      |
 
 ## Process
 
@@ -23,9 +23,9 @@ Help the user choose a display preset for their Howl statusline HUD.
    - Question: "Which Howl statusline preset would you like to use?"
    - Header: "Display Preset"
    - Options (4):
-     - Label: "full (default)" | Description: "Complete visibility - All 13 metrics (2-4 lines)"
+     - Label: "full (default)" | Description: "Complete visibility - All metrics (2-4 lines)"
      - Label: "minimal" | Description: "Clean workspace - Model + Context + Cost + Duration only (1 line)"
-     - Label: "developer" | Description: "Coding focus - Add Account, Git, Changes, Speed, Cache, Vim (2 lines)"
+     - Label: "developer" | Description: "Coding focus - Add Account, Git, Changes, Cache, Vim (2 lines)"
      - Label: "cost-focused" | Description: "Budget tracking - Add Quota, API Wait, Cost Velocity (2 lines)"
 
 2. **Show a preview** of their chosen preset:
@@ -40,7 +40,7 @@ Help the user choose a display preset for their Howl statusline HUD.
 
    ```
    [Sonnet 4.5] | ████░░░░░░░░░░░░░░░░ 21% (210K/1M) | $32.7 | 2h46m
-   user@example.com | main* | +2.7K/-120 | 50tok/s | Cache:96% | I
+   user@example.com | main* | +2.7K/-120 | Cache:96% | I
    ```
 
    **cost-focused:**
@@ -54,7 +54,7 @@ Help the user choose a display preset for their Howl statusline HUD.
 
    ```
    [Sonnet 4.5] | ████░░░░░░░░░░░░░░░░ 21% (210K/1M) | $32.7 | 2h46m
-   user@example.com | main* | +2.7K/-120 | 50tok/s | (2h)5h: 55%/42% :7d(3d6h)
+   user@example.com | main* | +2.7K/-120 | (2h)5h: 55%/42% :7d(3d6h)
    Read(9) Bash(8) TaskCreate(4) | ▶researcher,tester
    Cache:96% | Wait:41% | Cost:$0.19/m | I | @code-wri
    ```
@@ -107,9 +107,9 @@ This behavior cannot be disabled - it's a safety feature. The trigger point can 
 
 ### What Gets Hidden in Each Preset
 
-- **minimal**: Hides account, git, line changes, response speed, quota, tools, agents, cache, API wait ratio, cost velocity, vim mode, agent name, token breakdown
+- **minimal**: Hides account, git, line changes, quota, tools, agents, cache, API wait ratio, cost velocity, vim mode, agent name, token breakdown
 - **developer**: Hides quota, tools, agents, API wait ratio, cost velocity, agent name, token breakdown
-- **cost-focused**: Hides account, git, line changes, response speed, tools, agents, cache, vim mode, agent name, token breakdown
+- **cost-focused**: Hides account, git, line changes, tools, agents, cache, vim mode, agent name, token breakdown
 
 ### Refresh Rate
 
@@ -121,7 +121,7 @@ Configuration changes apply on the next statusline refresh, which occurs approxi
 User: I want a cleaner statusline
 Agent: I can help configure that! What's your priority?
 - Minimal (just essentials: model, context, cost, time)
-- Developer focus (+ git, changes, speed, cache)
+- Developer focus (+ git, changes, cache)
 - Cost tracking (+ quota, API wait, velocity)
 
 User: Minimal please

--- a/skills/customize/SKILL.md
+++ b/skills/customize/SKILL.md
@@ -41,7 +41,7 @@ Advanced configuration for Howl statusline: choose a base preset, toggle individ
   - Label: **"minimal"**  
     Description: "Model + Context + Cost + Duration only (1 line)"
   - Label: **"developer"**  
-    Description: "Coding focus: Account, Git, Changes, Speed, Cache, Vim (2 lines)"
+    Description: "Coding focus: Account, Git, Changes, Cache, Vim (2 lines)"
   - Label: **"cost-focused"**  
     Description: "Budget tracking: Quota, API Wait, Cost Velocity (2 lines)"
 
@@ -53,25 +53,30 @@ Advanced configuration for Howl statusline: choose a base preset, toggle individ
 
 - **Question**: "Select which metrics to display (pre-checked = enabled in your preset)"
 - **Header**: "Customize Metrics"
-- **Options** (12 checkboxes):
+- **Options** (17 checkboxes):
   1. **account** - Account email
   2. **git** - Git branch + status
   3. **line_changes** - Code additions/deletions
-  4. **response_speed** - Tokens per second
-  5. **quota** - Usage quota visualization
-  6. **tools** - Tool call counts
-  7. **agents** - Active agent indicators
-  8. **cache_efficiency** - Cache hit percentage
-  9. **api_wait_ratio** - API wait time ratio
-  10. **cost_velocity** - Cost per minute
-  11. **vim_mode** - Vim mode indicator
-  12. **agent_name** - Current agent name
+  4. **quota** - Usage quota visualization
+  5. **tools** - Tool call counts
+  6. **agents** - Active agent indicators
+  7. **cache_efficiency** - Cache hit percentage
+  8. **api_wait_ratio** - API wait time ratio
+  9. **cost_velocity** - Cost per minute
+  10. **vim_mode** - Vim mode indicator
+  11. **agent_name** - Current agent name
+  12. **output_tokens** - Current-response output token count (`Out:1K`) _(default off)_
+  13. **effort** - Effort level indicator (`E:high`) _(default off)_
+  14. **thinking** - Extended thinking indicator (`Think`) _(default off)_
+  15. **session_name** - Truncated session name _(default off)_
+  16. **pull_request** - Linked PR status (`PR#1234 pending`) _(default off)_
+  17. **worktree** - Active git worktree (`wt:name`) _(default off)_
 
 **Pre-check based on `chosenPreset`:**
 
-- **full**: All 12 checked
+- **full**: All core metrics checked (new optional toggles effort/thinking/session_name/pull_request/worktree unchecked)
 - **minimal**: None checked
-- **developer**: account, git, line_changes, response_speed, cache_efficiency, vim_mode
+- **developer**: account, git, line_changes, cache_efficiency, vim_mode
 - **cost-focused**: quota, api_wait_ratio, cost_velocity
 
 **Important: Features are Additive-Only**
@@ -100,12 +105,11 @@ Advanced configuration for Howl statusline: choose a base preset, toggle individ
 - **Question**: "Choose which metrics should appear first on Line 2 (max 5, ordered by selection)"
 - **Header**: "Display Priority (Optional)"
 - **Subtitle**: "Only Line 2 metrics can be prioritized. Selected order = display order."
-- **Options** (5 checkboxes, only Line 2 metrics):
+- **Options** (4 checkboxes, only Line 2 metrics):
   1. **account** - Account email
   2. **git** - Git branch + status
   3. **line_changes** - Code additions/deletions
-  4. **response_speed** - Tokens per second
-  5. **quota** - Usage quota visualization
+  4. **quota** - Usage quota visualization
 
 **Constraints:**
 
@@ -154,7 +158,7 @@ Priority: quota → git
 
 Preview (example):
 [Sonnet 4.5] | ████░░░░░░░░░░░░░░░░ 21% (210K/1M) | $32.7 | 2h46m
-(2h)5h: 55%/42% :7d(3d6h) | user@example.com | main* | +2.7K/-120 | 50tok/s | Cache:96% | I
+(2h)5h: 55%/42% :7d(3d6h) | user@example.com | main* | +2.7K/-120 | Cache:96% | I
 
 Changes will apply on next refresh (~300ms).
 ```
@@ -252,9 +256,10 @@ This override cannot be disabled - it's a safety feature. The trigger point can 
 ### Line Placement Rules
 
 - **Line 1**: Model badge, context bar, cost, duration (always shown)
-- **Line 2**: account, git, line_changes, response_speed, quota (prioritizable)
+- **Line 2**: account, git, line_changes, quota (prioritizable)
 - **Line 3**: tools, agents (only in `full` preset or danger mode)
 - **Line 4**: cache_efficiency, api_wait_ratio, cost_velocity, vim_mode, agent_name (only in `full` or danger mode)
+- **Optional** (default off): effort, thinking, session_name, pull_request, worktree
 
 ### Refresh Rate
 
@@ -278,8 +283,8 @@ Agent: I can help customize that! Let's walk through it.
 > developer
 
 [Step 2] Customize metrics (pre-checked based on developer):
-☑ account, git, line_changes, response_speed, cache_efficiency, vim_mode
-☐ quota, tools, agents, api_wait_ratio, cost_velocity, agent_name
+☑ account, git, line_changes, cache_efficiency, vim_mode
+☐ quota, tools, agents, api_wait_ratio, cost_velocity, agent_name, effort, thinking, session_name, pull_request, worktree
 > User also checks: quota
 
 [Step 3] Priority for Line 2 (max 5):

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -43,6 +43,27 @@ Inform the user:
 - Statusline configured in `~/.claude/settings.json`
 - **Restart Claude Code** to activate the statusline
 
+## Auto-Update
+
+Once installed, the binary keeps itself current automatically:
+
+- Claude Code auto-updates the **plugin** content (skills, scripts) from the marketplace.
+- The plugin's `SessionStart` hook (`scripts/sync-binary.sh`) then detects a plugin
+  version change and re-downloads the matching **binary** in the background — so the
+  binary never drifts from the plugin. It is a no-op (no network) when already in sync,
+  and only updates an existing install (it never installs unprompted).
+
+To receive updates, ensure marketplace auto-update is enabled for the Howl marketplace
+(third-party marketplaces are not auto-updated by default):
+
+```bash
+# Refresh the marketplace and update installed plugins
+claude plugin marketplace update ai-screams-howl
+```
+
+To force a binary update immediately, just re-run this setup (`/howl:setup`) or
+`bash "${CLAUDE_PLUGIN_ROOT}/scripts/install.sh"`.
+
 ## Troubleshooting
 
 If the install fails:

--- a/skills/threshold/SKILL.md
+++ b/skills/threshold/SKILL.md
@@ -15,7 +15,6 @@ Customize when Howl changes colors and switches modes. All 17 threshold values a
 | **Session Cost**  | `session_cost_high`, `session_cost_medium`                  | $5.00, $1.00                 | Cost display color                          |
 | **Cache**         | `cache_excellent`, `cache_good`                             | 80%, 50%                     | Cache efficiency color                      |
 | **API Wait**      | `wait_high`, `wait_medium`                                  | 60%, 35%                     | API wait ratio color                        |
-| **Speed**         | `speed_fast`, `speed_moderate`                              | 60, 30 tok/s                 | Response speed color                        |
 | **Cost Velocity** | `cost_velocity_high`, `cost_velocity_medium`                | $0.50, $0.10/min             | Cost velocity color                         |
 | **Quota**         | `quota_critical`, `quota_low`, `quota_medium`, `quota_high` | 10%, 25%, 50%, 75% remaining | Quota color bands                           |
 
@@ -27,7 +26,6 @@ Customize when Howl changes colors and switches modes. All 17 threshold values a
   "thresholds": {
     "context_danger": 90,
     "context_warning": 75,
-    "speed_fast": 100,
     "quota_critical": 5
   }
 }
@@ -81,7 +79,7 @@ Only specified thresholds override defaults. Omitted fields keep default values.
 - **Header**: "Select Group"
 - **Options** (4):
   - Label: **"Context & Danger"** | Description: "When danger mode activates (85%) and warning shows (70%)"
-  - Label: **"Performance"** | Description: "Speed (60/30 tok/s), Cache (80/50%), API Wait (60/35%)"
+  - Label: **"Performance"** | Description: "Cache (80/50%), API Wait (60/35%)"
   - Label: **"Cost"** | Description: "Session cost ($5/$1), Cost velocity ($0.50/$0.10/min)"
   - Label: **"Quota"** | Description: "Quota color bands (10/25/50/75% remaining)"
 
@@ -96,7 +94,6 @@ Based on selected group, ask for specific values.
 
 **Performance:**
 
-- Ask: "Set speed thresholds — Fast (green, default 60 tok/s) and Moderate (yellow, default 30 tok/s):"
 - Ask: "Set cache thresholds — Excellent (green, default 80%) and Good (yellow, default 50%):"
 - Ask: "Set API wait thresholds — High (red, default 60%) and Medium (yellow, default 35%):"
 
@@ -158,16 +155,14 @@ User wants danger mode at 90% instead of 85%:
 }
 ```
 
-### Example 2: Stricter Performance Thresholds
+### Example 2: Stricter Cache Thresholds
 
-User wants higher standards for "fast" speed:
+User wants higher standards for cache efficiency:
 
 ```json
 {
   "preset": "developer",
   "thresholds": {
-    "speed_fast": 100,
-    "speed_moderate": 50,
     "cache_excellent": 90,
     "cache_good": 70
   }

--- a/skills/threshold/SKILL.md
+++ b/skills/threshold/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: false
 
 # Howl Threshold
 
-Customize when Howl changes colors and switches modes. All 17 threshold values are configurable — they control when metrics turn green/yellow/orange/red and when danger mode activates.
+Customize when Howl changes colors and switches modes. All 15 threshold values are configurable — they control when metrics turn green/yellow/orange/red and when danger mode activates.
 
 ## Threshold Groups
 
@@ -50,7 +50,7 @@ Only specified thresholds override defaults. Omitted fields keep default values.
 **If "View Current":**
 
 1. Read `~/.claude/hud/config.json` (if exists)
-2. Display all 17 thresholds in a table, marking custom values with `*`
+2. Display all 15 thresholds in a table, marking custom values with `*`
 3. Done.
 
 **If "Reset All":**


### PR DESCRIPTION
## Summary

- **Schema sync**: `StdinData` extended with all CC 2.1 fields — `session_name`, `effort`, `thinking`, `rate_limits`, `pr`, `worktree`; `Workspace` gains `added_dirs`, `git_worktree`, `repo` (`RepoInfo` DTO); new `RateLimits`/`RateLimitWindow`, `Effort`, `Thinking`, `PullRequest`, `Worktree` DTOs
- **Quota via stdin**: `GetUsage(sessionID)` (OAuth + Keychain + /tmp cache) replaced by `UsageFromRateLimits(*RateLimits)` — pure function, no network call, no Keychain, no /tmp. **Requires CC 2.1.80+ and a Claude.ai subscriber session** to see quota bars
- **ResponseSpeed removed**: the cumulative tok/s metric was misleading; replaced by `output_tokens` toggle (`Out:NK`) reading `current_usage.output_tokens` directly
- **New render features** (all default off, opt-in via config `features`): `output_tokens`, `effort`, `thinking`, `session_name`, `pull_request`, `worktree`
- **Quota pace marker**: `renderQuotaBar` appends 🔥 when a rate-limit window is projected to exhaust before reset (single-snapshot math, no history)
- **Width-aware tool line**: `terminalColumns()` reads `COLUMNS` env var set by CC 2.1.153+ (clamped 40–240, falls back to 80)
- **Installer**: `scripts/install.sh` now writes `refreshInterval` and `hideVimModeIndicator` defaults for CC 2.1

## Notes

- `.docs/` is intentionally excluded from all commits (internal-only, repo rule)
- `SpeedFast`/`SpeedModerate` thresholds removed; configurable threshold count drops from 17 → 15
- No breaking changes to existing config files — new toggles default off, missing fields ignored

## Commits

| SHA | Description |
|-----|-------------|
| `6930dc7` | feat: sync StdinData with Claude Code 2.1 statusline schema |
| `13028a4` | feat: source quota from stdin rate_limits, remove OAuth/Keychain path |
| `4e3720b` | refactor: replace disabled ResponseSpeed with output_tokens toggle, add CC 2.1 feature flags |
| `6582557` | feat: modernize render layer for CC 2.1 (quota model, new metrics, width-aware tools) |
| `6a16c04` | feat: write modern statusLine settings in installer |
| `ad47f11` | docs: update README and skills for CC 2.1 statusline modernization |

## Test plan

- [ ] `go build ./... && go vet ./... && go test ./...` all pass on branch tip
- [ ] Quota bars appear when piping JSON with `rate_limits.five_hour` / `rate_limits.seven_day` populated
- [ ] Quota bars absent (no fake 0% bar) when `rate_limits` is missing from stdin
- [ ] 🔥 pace marker appears on a quota bar when used% is ahead of even time-based pace
- [ ] Optional renderers (`effort`, `thinking`, `session_name`, `pull_request`, `worktree`) off by default; appear when enabled in `config.json`
- [ ] Tool line respects `COLUMNS` env var (set `COLUMNS=60` and verify truncation)
- [ ] Fresh install via `scripts/install.sh` produces correct CC 2.1 statusline config block